### PR TITLE
Reduce composer package size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.lock export-ignore
+composer.sh export-ignore
+Dockerfile.dev export-ignore
+phpstan.neon export-ignore


### PR DESCRIPTION
This PR introduces a new `.gitattributes` file to the repository that reduces the size of the distributed Composer package.

This applies when installing the package with `--prefer-dist` (which is the default behavior).

```
composer install growthbook/growthbook --prefer-dist
```

The package can still be installed with all files using `--prefer-source` if need be.

```
composer install growthbook/growthbook --prefer-source
```


