### PR TITLE
Fix broken logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://www.growthbook.io/logos/growthbook-logo@2x.png" width="400px" /></p>
+<p align="center"><img src="https://cdn.growthbook.io/growthbook-logo@2x.png" width="400px" /></p>
 
 # Growth Book - PHP
 


### PR DESCRIPTION
This PR fixes the broken logo in the README.

The original points to `https://www.growthbook.io/logos/growthbook-logo@2x.png` which returns a 404.

I've replaced it with `https://cdn.growthbook.io/growthbook-logo@2x.png`