### PR TITLE
add version 2 and 3 of PSR log to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Library to run AB tests using the Growth Book experiment platform",
     "type": "library",
     "require": {
-        "psr/log": "~1.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Currently this package cannot be used by project that require higher version of psr/log
adding version 2 and 3 will not break funcitonality
same is used by symfony/cache package: https://github.com/symfony/cache/blob/5.4/composer.json#L26