### PR TITLE
Update namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $apiResponse = json_decode(file_get_contents(FEATURES_ENDPOINT), true);
 $features = $apiResponse["features"];
 
 // Create a GrowthBook instance
-$growthbook = Growthbook\Growthbook::create()
+$growthbook = GrowthBook\GrowthBook::create()
   ->withFeatures($features)
   ->withAttributes([
     'id' => $userId,
@@ -73,16 +73,16 @@ foreach($impressions as $impression) {
 
 
 
-The `Growthbook` class has a number of properties.  These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:
+The `GrowthBook` class has a number of properties.  These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:
 
 ```php
 // Using the fluent interface
-$growthbook = Growthbook\Growthbook::create()
+$growthbook = GrowthBook\GrowthBook::create()
   ->withFeatures($features)
   ->withAttributes($attributes);
 
 // Using the constructor
-$growthbook = new Growthbook\Growthbook([
+$growthbook = new GrowthBook\GrowthBook([
   'features' => $features,
   'attributes' => $attributes
 ]);
@@ -158,8 +158,8 @@ You can either do this via a callback function:
 
 ```php
 $trackingCallback = function (
-  Growthbook\InlineExperiment $experiment, 
-  Growthbook\ExperimentResult $result
+  GrowthBook\InlineExperiment $experiment, 
+  GrowthBook\ExperimentResult $result
 ) {  
   // Segment.io example
   Segment::track([
@@ -173,7 +173,7 @@ $trackingCallback = function (
 };
 
 // Fluent interface
-$growthbook = Growthbook\Growthbook::create()
+$growthbook = GrowthBook\GrowthBook::create()
   ->withTrackingCallback($callback);
 
 // Using the construtor
@@ -280,7 +280,7 @@ As you can see, there are 2 required parameters for experiments, a string key, a
 There are a number of additional settings to control the experiment behavior. The methods are all chainable. Here's an example that shows all of the possible settings:
 
 ```php
-$exp = Growthbook\InlineExperiment::create("my-experiment", ["red","blue"])
+$exp = GrowthBook\InlineExperiment::create("my-experiment", ["red","blue"])
   // Run a 40/60 experiment instead of the default even split (50/50)
   ->withWeights([0.4, 0.6])
   // Only include 20% of users in the experiment

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload": {
 		"psr-4": {
-			"Growthbook\\": "src/"
+			"GrowthBook\\": "src/"
 		}
 	}
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/Condition.php
+++ b/src/Condition.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 class Condition
 {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/ExperimentOverride.php
+++ b/src/ExperimentOverride.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/ExperimentResult.php
+++ b/src/ExperimentResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/FeatureResult.php
+++ b/src/FeatureResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/FeatureRule.php
+++ b/src/FeatureRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/GrowthBook.php
+++ b/src/GrowthBook.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
-class Growthbook
+class GrowthBook
 {
     /** @var bool */
     public $enabled = true;
@@ -24,9 +24,9 @@ class Growthbook
     /** @var array<string,ViewedExperiment> */
     private $tracks = [];
 
-    public static function create(): Growthbook
+    public static function create(): GrowthBook
     {
-        return new Growthbook();
+        return new GrowthBook();
     }
 
     /**
@@ -59,27 +59,27 @@ class Growthbook
 
     /**
      * @param array<string,mixed> $attributes
-     * @return Growthbook
+     * @return GrowthBook
      */
-    public function withAttributes(array $attributes): Growthbook
+    public function withAttributes(array $attributes): GrowthBook
     {
         $this->attributes = $attributes;
         return $this;
     }
     /**
      * @param callable|null $trackingCallback
-     * @return Growthbook
+     * @return GrowthBook
      */
-    public function withTrackingCallback($trackingCallback): Growthbook
+    public function withTrackingCallback($trackingCallback): GrowthBook
     {
         $this->trackingCallback = $trackingCallback;
         return $this;
     }
     /**
      * @param array<string,Feature<mixed>|mixed> $features
-     * @return Growthbook
+     * @return GrowthBook
      */
-    public function withFeatures(array $features): Growthbook
+    public function withFeatures(array $features): GrowthBook
     {
         $this->features = [];
         foreach ($features as $key=>$feature) {
@@ -93,23 +93,23 @@ class Growthbook
     }
     /**
      * @param array<string,int> $forcedVariations
-     * @return Growthbook
+     * @return GrowthBook
      */
-    public function withForcedVariations(array $forcedVariations): Growthbook
+    public function withForcedVariations(array $forcedVariations): GrowthBook
     {
         $this->forcedVariations = $forcedVariations;
         return $this;
     }
     /**
      * @param string $url
-     * @return Growthbook
+     * @return GrowthBook
      */
-    public function withUrl(string $url): Growthbook
+    public function withUrl(string $url): GrowthBook
     {
         $this->url = $url;
         return $this;
     }
-    public function withLogger(\Psr\Log\LoggerInterface $logger = null): Growthbook
+    public function withLogger(\Psr\Log\LoggerInterface $logger = null): GrowthBook
     {
         $this->logger = $logger;
         return $this;

--- a/src/InlineExperiment.php
+++ b/src/InlineExperiment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/OldExperimentResult.php
+++ b/src/OldExperimentResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/TrackData.php
+++ b/src/TrackData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @template T

--- a/src/User.php
+++ b/src/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 /**
  * @deprecated

--- a/src/ViewedExperiment.php
+++ b/src/ViewedExperiment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Growthbook;
+namespace GrowthBook;
 
 class ViewedExperiment
 {

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use Growthbook\Condition;
-use Growthbook\Growthbook;
-use Growthbook\InlineExperiment;
+use GrowthBook\Condition;
+use GrowthBook\GrowthBook;
+use GrowthBook\InlineExperiment;
 use PHPUnit\Framework\TestCase;
 
 final class GrowthbookTest extends TestCase
@@ -52,7 +52,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testGetBucketRange(array $args, array $expected): void
     {
-        $actual = Growthbook::getBucketRanges($args[0], $args[1], $args[2]);
+        $actual = GrowthBook::getBucketRanges($args[0], $args[1], $args[2]);
         $this->assertSame(count($expected), count($actual));
         foreach ($actual as $k => $v) {
             $this->assertSame(count($expected[$k]), count($v));
@@ -75,7 +75,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testHash(string $value, float $expected): void
     {
-        $this->assertSame(Growthbook::hash($value), $expected);
+        $this->assertSame(GrowthBook::hash($value), $expected);
     }
     /**
      * @return array<int|string,mixed[]>
@@ -110,7 +110,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testGetQueryStringOverride(string $key, string $url, int $numVariations, ?int $expected): void
     {
-        $this->assertSame(Growthbook::getQueryStringOverride($key, $url, $numVariations), $expected);
+        $this->assertSame(GrowthBook::getQueryStringOverride($key, $url, $numVariations), $expected);
     }
     /**
      * @return array<int|string,mixed[]>
@@ -129,7 +129,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testChooseVariation(float $n, array $ranges, int $expected): void
     {
-        $this->assertSame(Growthbook::chooseVariation($n, $ranges), $expected);
+        $this->assertSame(GrowthBook::chooseVariation($n, $ranges), $expected);
     }
     /**
      * @return array<int|string,mixed[]>
@@ -148,7 +148,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testInNamespace(string $id, array $namespace, bool $expected): void
     {
-        $this->assertSame(Growthbook::inNamespace($id, $namespace), $expected);
+        $this->assertSame(GrowthBook::inNamespace($id, $namespace), $expected);
     }
     /**
      * @return array<int|string,mixed[]>
@@ -166,7 +166,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testGetEqualWeights(int $numVariations, array $expected): void
     {
-        $weights = Growthbook::getEqualWeights($numVariations);
+        $weights = GrowthBook::getEqualWeights($numVariations);
 
         $this->assertSame(array_map(function ($w) {
             return round($w, 8);
@@ -191,7 +191,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testFeature(array $ctx, string $key, array $expected): void
     {
-        $gb = new Growthbook($ctx);
+        $gb = new GrowthBook($ctx);
         $res = $gb->getFeature($key);
 
         $actual = [
@@ -249,7 +249,7 @@ final class GrowthbookTest extends TestCase
      */
     public function testRun(array $ctx, array $exp, $expectedValue, bool $inExperiment): void
     {
-        $gb = new Growthbook($ctx);
+        $gb = new GrowthBook($ctx);
         $experiment = new InlineExperiment($exp["key"], $exp["variations"], $exp);
         $res = $gb->runInlineExperiment($experiment);
 
@@ -277,7 +277,7 @@ final class GrowthbookTest extends TestCase
         $url = "/home";
         $forcedVariations = ['exp1'=>0];
 
-        $gb = Growthbook::create()
+        $gb = GrowthBook::create()
             ->withFeatures($features)
             ->withAttributes($attributes)
             ->withTrackingCallback($callback)

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -2,10 +2,10 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use Growthbook\Client;
-use Growthbook\Experiment;
-use Growthbook\User;
-use Growthbook\Util;
+use GrowthBook\Client;
+use GrowthBook\Experiment;
+use GrowthBook\User;
+use GrowthBook\Util;
 use PHPUnit\Framework\TestCase;
 
 final class UserTest extends TestCase


### PR DESCRIPTION
This PR renames the current `Growthbook` namespace to `GrowthBook` (capital B) to make it consistent with the branding. It also renames the `Growthbook` class to `GrowthBook`.

These changes are not breaking because PHP is case-insensitive when it comes to class names and namespaces.

Tests return green.