### PR TITLE
Fix deprecation warning on PHP 8.1 and later

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -192,7 +192,7 @@ class Condition
             case '$gte':
                 return $attributeValue >= $conditionValue;
             case '$regex':
-                return @preg_match('/'.$conditionValue.'/', $attributeValue) === 1;
+                return preg_match('/'.$conditionValue.'/', $attributeValue ?? '') === 1;
             case '$in':
                 if (!is_array($conditionValue)) {
                     return false;


### PR DESCRIPTION
## Fix deprecation warning on PHP 8.1 and later

### Description
Get rid of warning on PHP version 8.1 and higher
```
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated
```