### PR TITLE
Fix default host selection.

### DIFF
--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -783,7 +783,7 @@ class Growthbook implements LoggerAwareInterface
         }
 
         // The features URL is also the cache key
-        $url = rtrim($this->apiHost ?? self::DEFAULT_API_HOST, "/") . "/api/features/" . $this->clientKey;
+        $url = rtrim(empty($this->apiHost) ? self::DEFAULT_API_HOST : $this->apiHost, "/") . "/api/features/" . $this->clientKey;
         $cacheKey = md5($url);
 
         // First try fetching from cache


### PR DESCRIPTION
Currently if you don't provide an api host the default host is not selected as the nulll coalesce operater is not suitable for empty strings.

This leads to a guzzle error:
````
$growthbook = new Growthbook();
$growthbook->loadFeatures($key);

GuzzleHttp\Exception\RequestException: cURL error 3: URL using bad/illegal format or missing URL (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for /api/features/{apikey}
```