### PR TITLE
Fix unit test

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -192,7 +192,7 @@ class Condition
             case '$gte':
                 return $attributeValue >= $conditionValue;
             case '$regex':
-                return preg_match('/'.$conditionValue.'/', $attributeValue ?? '') === 1;
+                return @preg_match('/'.$conditionValue.'/', $attributeValue ?? '') === 1;
             case '$in':
                 if (!is_array($conditionValue)) {
                     return false;


### PR DESCRIPTION
On #20 we fixed a deprecation warning but we also inadvertently changed the behavior of the function which broke unit test.

By removing `@` from the start, we consider an error if the provided regex is invalid, which is not the intended behavior. We want to instead ignore the invalid regex and return `null` as if there was no match.

As this is a behavior covered by our unit tests, I am restoring the error suppression `@`.