### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer downloads
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{hashFiles('**/composer.lock') }}


### PR DESCRIPTION
As of March 1st, `actions/cache@v1` is deprecated, so we are updating to v4 as described [here](https://github.com/actions/cache/discussions/1510).