### PR TITLE
Add saved groups + ruleId + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Powerful Feature flagging and A/B testing for PHP.
 
 ![Build Status](https://github.com/growthbook/growthbook-php/workflows/Build/badge.svg)
 
--  **No external dependencies** (besides PSR interfaces)
--  **Extremely fast**, all evaluation happens locally
--  **PHP 7.1+** with 100% test coverage and phpstan on the highest level
--  **Advanced user and page targeting**
--  **Use your existing event tracking** (GA, Segment, Mixpanel, custom)
--  **Adjust variation weights and targeting** without deploying new code
+- **No external dependencies** (besides PSR interfaces)
+- **Extremely fast**, all evaluation happens locally
+- **PHP 7.1+** with 100% test coverage and phpstan on the highest level
+- **Advanced user and page targeting**
+- **Use your existing event tracking** (GA, Segment, Mixpanel, custom)
+- **Adjust variation weights and targeting** without deploying new code
 
 ## Installation
 
@@ -32,7 +32,7 @@ $growthbook = Growthbook\Growthbook::create()
 
 // Load feature flags from the GrowthBook API
 // Make sure to use caching in production! (see 'Loading Features' below)
-$growthbook->loadFeatures("sdk-abc123", "https://cdn.growthbook.io");
+$growthbook->initialize("sdk-abc123", "https://cdn.growthbook.io");
 
 // Feature gating
 if ($growthbook->isOn("my-feature")) {
@@ -67,11 +67,11 @@ foreach($impressions as $impression) {
 
 ### Loading Features
 
-There are 2 ways to load features into the SDK.  You can use `loadFeatures` with a Client Key and API Host.  Or, you can manually fetch and cache feature flags and pass them in with the `withFeatures` method.
+There are 2 ways to load features into the SDK. You can use `initialize` with a Client Key and API Host. Or, you can manually fetch and cache feature flags and pass them in with the `withFeatures` method.
 
-#### loadFeatures method
+#### initialize method
 
-The `loadFeatures` method can fetch features from the GrowthBook API for you.
+The `initialize` method can fetch features from the GrowthBook API for you.
 
 By default, there is no caching enabled. You can enable it by passing any PSR16-compatible instance into the `withCache` method.
 
@@ -93,9 +93,9 @@ $growthbook = Growthbook\Growthbook::create()
 
 To load features, we require a PSR-17 (HttpClient) and PSR-18 (RequestFactoryInterface) compatible library like Guzzle to be installed.
 
-We will auto-discover most HTTP libraries without any configuration required, but if you prefer to specify it explicitly, you can use the `withHttpClient` method.  Note - you'll need to specify both an `HttpClient` and a `RequestFactoryInterface` implementation.
+We will auto-discover most HTTP libraries without any configuration required, but if you prefer to specify it explicitly, you can use the `withHttpClient` method. Note - you'll need to specify both an `HttpClient` and a `RequestFactoryInterface` implementation.
 
-The `loadFeatures` method takes 3 arguments:
+The `initialize` method takes 3 arguments:
 
 - `$clientKey` (required) - Get this from your SDK Connection in GrowthBook.
 - `$apiHost` (optional) - Defaults to `https://cdn.growthbook.io`. If self-hosting GrowthBook, set this to your API host.
@@ -119,7 +119,7 @@ $growthbook = Growthbook\Growthbook::create()
 
 ## The Growthbook Class
 
-The `Growthbook` class has a number of properties.  These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:
+The `Growthbook` class has a number of properties. These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:
 
 ```php
 // Using the fluent interface
@@ -162,7 +162,7 @@ $attributes = [
 ];
 ```
 
-If you want to update attributes later, please note that the `withAttributes` method completely overwrites the attributes object.  You can use `array_merge` if you only want to update a subset of fields:
+If you want to update attributes later, please note that the `withAttributes` method completely overwrites the attributes object. You can use `array_merge` if you only want to update a subset of fields:
 
 ```php
 // Only update the url attribute
@@ -182,9 +182,9 @@ You can either do this via a callback function:
 
 ```php
 $trackingCallback = function (
-  Growthbook\InlineExperiment $experiment, 
+  Growthbook\InlineExperiment $experiment,
   Growthbook\ExperimentResult $result
-) {  
+) {
   // Segment.io example
   Segment::track([
     "userId" => $userId,
@@ -239,32 +239,35 @@ Or, you can pass the impressions onto your front-end and fire analytics events f
 Below are examples for a few popular front-end tracking libraries:
 
 #### Google Analytics
+
 ```php
-ga('send', 'event', 'experiment', 
-  "<?= $impression->experiment->key ?>", 
-  "<?= $impression->result->variationId ?>", 
+ga('send', 'event', 'experiment',
+  "<?= $impression->experiment->key ?>",
+  "<?= $impression->result->variationId ?>",
   {
     // Custom dimension for easier analysis
-    'dimension1': "<?= 
-      $impression->experiment->key.':'.$impression->result->key 
+    'dimension1': "<?=
+      $impression->experiment->key.':'.$impression->result->key
     ?>"
   }
 );
 ```
 
 #### Segment
+
 ```php
 analytics.track("Experiment Viewed", <?=json_encode([
   "experimentId" => $impression->experiment->key,
-  "variationId" => $impression->result->key 
+  "variationId" => $impression->result->key
 ])?>);
 ```
 
 #### Mixpanel
+
 ```php
 mixpanel.track("Experiment Viewed", <?=json_encode([
   'Experiment name' => $impression->experiment->key,
-  'Variant name' => $impression->result->key 
+  'Variant name' => $impression->result->key
 ])?>);
 ```
 
@@ -292,7 +295,6 @@ There are 3 main methods for interacting with features.
 - `$growthbook->isOff("feature-key")` returns false if the feature is on
 - `$growthbook->getValue("feature-key", "default")` returns the value of the feature with a fallback
 
-
 In addition, you can use `$growthbook->getFeature("feature-key")` to get back a `FeatureResult` object with the following properties:
 
 - **value** - The JSON-decoded value of the feature (or `null` if not defined)
@@ -300,7 +302,6 @@ In addition, you can use `$growthbook->getFeature("feature-key")` to get back a 
 - **source** - Why the value was assigned to the user. One of `unknownFeature`, `defaultValue`, `force`, or `experiment`
 - **experiment** - Information about the experiment (if any) which was used to assign the value to the user
 - **experimentResult** - The result of the experiment (if any) which was used to assign the value to the user
-
 
 ## Sticky Bucketing
 
@@ -370,15 +371,15 @@ Instead of declaring all features up-front and referencing them by ids in your c
 
 ```php
 $exp = Growthbook\InlineExperiment::create(
-  "my-experiment", 
+  "my-experiment",
   ["red", "blue", "green"]
 );
 
 // Either "red", "blue", or "green"
-echo $growthbook->runInlineExperiment($exp)->value; 
+echo $growthbook->runInlineExperiment($exp)->value;
 ```
 
-As you can see, there are 2 required parameters for experiments, a string key, and an array of variations.  Variations can be any data type, not just strings.
+As you can see, there are 2 required parameters for experiments, a string key, and an array of variations. Variations can be any data type, not just strings.
 
 There are a number of additional settings to control the experiment behavior. The methods are all chainable. Here's an example that shows all of the possible settings:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The `initialize` method takes 3 arguments:
 
 If you prefer to have full control over the fetching/caching behavior, you can use the `withFeatures` method instead to pass an associative array of features into the SDK.
 
+#### withSavedGroups method
+
+If you're using saved groups and not using the `initialize` method, you'll need to call `withSavedGroups` to provide the saved groups data to the SDK.
+
 ```php
 // From the GrowthBook API, a custom cache layer, or somewhere else
 $featuresJSON = '{"my-feature":{"defaultValue":true}}';
@@ -115,6 +119,11 @@ $features = json_decode($featuresJSON, true);
 // Pass into the Growthbook instance
 $growthbook = Growthbook\Growthbook::create()
   ->withFeatures($features);
+
+// Optionally, if using saved groups
+$savedGroupsJSON = '{"myGroup": [1, 2, 3]}';
+$savedGroups = json_decode($savedGroupsJSON, true);
+$growthbook = $growthbook->withSavedGroups($savedGroups);
 ```
 
 ## The Growthbook Class

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "license": "MIT",
     "scripts": {
         "test": "XDEBUG_MODE=coverage phpunit tests --coverage-html coverage --coverage-filter src/",
-        "lint": "phpstan analyse",
+        "lint": "phpstan analyse --memory-limit=300M",
         "fix": "php-cs-fixer fix src && php-cs-fixer fix tests"
     },
     "autoload": {

--- a/src/Condition.php
+++ b/src/Condition.php
@@ -197,6 +197,10 @@ class Condition
      */
     private static function compare($val1, $val2): int
     {
+        if (is_bool($val1) || is_bool($val2)) {
+            return $val1 !== null && $val2 !== null && !!$val1 === !!$val2 ? 0 : 1;
+        }
+
         if ((is_int($val1) || is_float($val1)) && !(is_int($val2) || is_float($val2))) {
             if ($val2 === null) {
                 $val2 = 0;

--- a/src/Condition.php
+++ b/src/Condition.php
@@ -11,22 +11,36 @@ class Condition
      */
     public static function evalCondition(array $attributes, array $condition): bool
     {
-        if (isset($condition['$or'])) {
-            return static::evalOr($attributes, $condition['$or']);
-        }
-        if (isset($condition['$nor'])) {
-            return !static::evalOr($attributes, $condition['$nor']);
-        }
-        if (isset($condition['$and'])) {
-            return static::evalAnd($attributes, $condition['$and']);
-        }
-        if (isset($condition['$not'])) {
-            return !static::evalCondition($attributes, $condition['$not']);
-        }
-
         foreach ($condition as $key => $value) {
-            if (!static::evalConditionValue($value, static::getPath($attributes, $key))) {
-                return false;
+            switch ($key) {
+                case '$or':
+                    if (!static::evalOr($attributes, $condition['$or'])) {
+                        return false;
+                    }
+                    break;
+
+                case '$nor':
+                    if (static::evalOr($attributes, $condition['$nor'])) {
+                        return false;
+                    }
+                    break;
+
+                case '$and':
+                    if (!static::evalAnd($attributes, $condition['$and'])) {
+                        return false;
+                    }
+                    break;
+
+                case '$not':
+                    if (static::evalCondition($attributes, $condition['$not'])) {
+                        return false;
+                    }
+                    break;
+
+                default:
+                    if (!static::evalConditionValue($value, static::getPath($attributes, $key))) {
+                        return false;
+                    }
             }
         }
         return true;

--- a/src/FeatureResult.php
+++ b/src/FeatureResult.php
@@ -31,14 +31,19 @@ class FeatureResult
      * @var null|ExperimentResult<T>
      */
     public $experimentResult;
+    /**
+     * @var null|string
+     */
+    public $ruleId;
 
     /**
      * @param T $value
      * @param string $source
      * @param null|InlineExperiment<T> $experiment
      * @param null|ExperimentResult<T> $experimentResult
+     * @param null|string $ruleId
      */
-    public function __construct($value, string $source, ?InlineExperiment $experiment = null, ?ExperimentResult $experimentResult = null)
+    public function __construct($value, string $source, ?InlineExperiment $experiment = null, ?ExperimentResult $experimentResult = null, ?string $ruleId = null)
     {
         $this->value = $value;
         $this->on = !!$value;
@@ -46,5 +51,6 @@ class FeatureResult
         $this->source = $source;
         $this->experiment = $experiment;
         $this->experimentResult = $experimentResult;
+        $this->ruleId = $ruleId;
     }
 }

--- a/src/FeatureRule.php
+++ b/src/FeatureRule.php
@@ -7,6 +7,8 @@ namespace Growthbook;
  */
 class FeatureRule
 {
+    /** @var null|string */
+    public $id;
     /** @var null|array<string,mixed> */
     public $condition;
     /** @var null|float */
@@ -54,10 +56,13 @@ class FeatureRule
     public $parentConditions;
 
     /**
-     * @param array{condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>} $rule
+     * @param array{id?:string,condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>} $rule
      */
     public function __construct(array $rule)
     {
+        if (array_key_exists("id", $rule)) {
+            $this->id = $rule["id"];
+        }
         if (array_key_exists("condition", $rule)) {
             $this->condition = $rule["condition"];
         }

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -368,7 +368,7 @@ class Growthbook implements LoggerAwareInterface
         $this->log(LogLevel::DEBUG, "Evaluating feature - $key");
         $feature = $this->features[$key];
 
-        if(in_array($key, $stack)) {
+        if (in_array($key, $stack)) {
             $this->log(LogLevel::WARNING, "Cyclic prerequisite detected, stack", [
                 "stack" => $stack,
             ]);
@@ -758,6 +758,10 @@ class Growthbook implements LoggerAwareInterface
     {
         if ($coverage === null && $range === null) {
             return true;
+        }
+
+        if ($coverage === 0.0 && $range === null) {
+            return false;
         }
 
         list(, $hashValue) = $this->getHashValue($hashAttribute, $fallbackAttribute);

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -477,7 +477,7 @@ class Growthbook implements LoggerAwareInterface
                         "feature" => $key,
                         "value" => $rule->force
                     ]);
-                    return new FeatureResult($rule->force, "force");
+                    return new FeatureResult($rule->force, "force", null, null, $rule->id);
                 }
                 $exp = $rule->toExperiment($key);
                 if (!$exp) {
@@ -504,7 +504,7 @@ class Growthbook implements LoggerAwareInterface
                     "feature" => $key,
                     "value" => $result->value
                 ]);
-                return new FeatureResult($result->value, "experiment", $exp, $result);
+                return new FeatureResult($result->value, "experiment", $exp, $result, $rule->id);
             }
         }
         return new FeatureResult($feature->defaultValue ?? null, "defaultValue");

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -246,7 +246,8 @@ final class GrowthbookTest extends TestCase
             'value' => $res->value,
             'on' => $res->on,
             'off' => $res->off,
-            'source' => $res->source
+            'source' => $res->source,
+            'ruleId' => $res->ruleId,
         ];
 
         if ($res->experiment) {

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -99,10 +99,11 @@ final class GrowthbookTest extends TestCase
      * @param array<string,mixed> $condition
      * @param array<string,mixed> $attributes
      * @param bool $expected
+     * @param array<string,mixed> $savedGroups
      */
-    public function testEvalCondition(array $condition, array $attributes, bool $expected): void
+    public function testEvalCondition(array $condition, array $attributes, bool $expected, array $savedGroups = []): void
     {
-        $this->assertSame(Condition::evalCondition($attributes, $condition), $expected);
+        $this->assertSame(Condition::evalCondition($attributes, $condition, $savedGroups), $expected);
     }
 
     /**

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -110,25 +110,7 @@ final class GrowthbookTest extends TestCase
      */
     public function evalConditionProvider(): array
     {
-        $versionCompare = $this->getCases("versionCompare");
-        $versionCases = [];
-        foreach ($versionCompare as $comparison => $testCases) {
-            foreach ($testCases as $case) {
-                $versionCases["versionCompare: " . $case[0] . ' ' . $comparison . ' ' . $case[1]] = [
-                    [
-                        'v' => [
-                            '$v' . $comparison => $case[1]
-                        ]
-                    ],
-                    [
-                        'v' => $case[0]
-                    ],
-                    $case[2]
-                ];
-            }
-        }
-
-        return array_merge($this->getCases("evalCondition"), $versionCases);
+        return $this->getCases("evalCondition");
     }
 
 
@@ -571,8 +553,10 @@ final class GrowthbookTest extends TestCase
         $this->assertEquals(0, $gb->getFeature('feature')->value);
 
         $this->assertEquals(
-            ['attributeName' => 'id', 'attributeValue' => 1, 'assignments' => ['exp__0' => 'variation1',
-                "exp__1" => "control"]],
+            ['attributeName' => 'id', 'attributeValue' => 1, 'assignments' => [
+                'exp__0' => 'variation1',
+                "exp__1" => "control"
+            ]],
             $service->getAssignments('id', 1)
         );
     }

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.0",
+  "specVersion": "0.7.1",
   "evalCondition": [
     [
       "$not - pass",
@@ -1674,6 +1674,32 @@
       false
     ],
     [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": { "$eq": false }
+      },
+      {},
+      false
+    ],
+    [
       "$vgt/$vlt - pass - major",
       {
         "version": {
@@ -3040,7 +3066,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "unknownFeature"
+        "source": "unknownFeature",
+        "ruleId": ""
       }
     ],
     [
@@ -3051,7 +3078,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3062,7 +3090,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3073,7 +3102,8 @@
         "value": "yes",
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3095,7 +3125,32 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule with rule id",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "a"
       }
     ],
     [
@@ -3117,7 +3172,8 @@
         "value": false,
         "on": false,
         "off": true,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3143,7 +3199,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3169,7 +3226,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3183,6 +3241,7 @@
             "defaultValue": 2,
             "rules": [
               {
+                "id": "a",
                 "force": 1,
                 "coverage": 0.5
               }
@@ -3195,7 +3254,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3219,7 +3279,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3246,7 +3307,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3276,7 +3338,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3306,7 +3369,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3333,7 +3397,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3350,7 +3415,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3390,7 +3456,8 @@
           "key": "2",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -3403,6 +3470,7 @@
           "feature": {
             "rules": [
               {
+                "id": "id",
                 "variations": ["a", "b", "c"]
               }
             ]
@@ -3430,7 +3498,8 @@
           "key": "0",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": "id"
       }
     ],
     [
@@ -3470,7 +3539,8 @@
           "key": "1",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -3515,7 +3585,8 @@
                 "key": "hello",
                 "variations": [true, false],
                 "weights": [0.1, 0.9],
-                "condition": { "premium": true }
+                "condition": { "premium": true },
+                "foo": "bar"
               }
             ]
           }
@@ -3573,7 +3644,8 @@
           "key": "v1",
           "name": "variation 1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3607,7 +3679,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3622,13 +3695,16 @@
             "rules": [
               {
                 "force": 1,
+                "id": "1",
                 "condition": { "browser": "chrome" }
               },
               {
+                "id": "2",
                 "force": 2,
                 "condition": { "browser": "firefox" }
               },
               {
+                "id": "3",
                 "force": 3,
                 "condition": { "browser": "safari" }
               }
@@ -3641,7 +3717,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": "3"
       }
     ],
     [
@@ -3675,7 +3752,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3702,7 +3780,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3729,7 +3808,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3768,7 +3848,8 @@
           "key": "1",
           "bucket": 0.863,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3795,7 +3876,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3839,7 +3921,8 @@
           "hashValue": "123",
           "key": "1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3866,7 +3949,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3893,7 +3977,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3919,7 +4004,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3950,7 +4036,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3978,7 +4065,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4045,7 +4133,8 @@
           "variationId": 0,
           "bucket": 0.4413,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4118,7 +4207,8 @@
           "variationId": 0,
           "bucket": 0.8043,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4168,7 +4258,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4205,7 +4296,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4255,7 +4347,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4323,7 +4416,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4391,7 +4485,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4443,7 +4538,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4495,7 +4591,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4540,7 +4637,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "cyclicPrerequisite"
+        "source": "cyclicPrerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4558,7 +4656,7 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "$ne": false },
+                    "condition": { "value": { "$ne": false } },
                     "gate": true
                   },
                   {
@@ -4604,7 +4702,8 @@
         "value": "T",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4629,7 +4728,13 @@
         }
       },
       "inGroup_force_rule",
-      { "value": true, "on": true, "off": false, "source": "force" }
+      {
+        "value": true,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
     ],
     [
       "SavedGroups correctly pulled from context for experiment rule",
@@ -4685,7 +4790,8 @@
           "variationId": 0,
           "bucket": 0.1736,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ]
   ],

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.5.4",
+  "specVersion": "0.6.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -2019,79 +2019,817 @@
         "v": "1.2.3-alpha"
       },
       true
+    ],
+    [
+      "version 0.9.99 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "0.9.99"
+      },
+      true
+    ],
+    [
+      "version 0.9.0 < 0.10.0",
+      {
+        "version": {
+          "$vlt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.9.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0.0 < 1.0.0-0.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0-0.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-0.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-9999 < 1.0.0--",
+      {
+        "version": {
+          "$vlt": "1.0.0--"
+        }
+      },
+      {
+        "version": "1.0.0-9999"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-99 < 1.0.0-100",
+      {
+        "version": {
+          "$vlt": "1.0.0-100"
+        }
+      },
+      {
+        "version": "1.0.0-99"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha < 1.0.0-alpha.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.1"
+        }
+      },
+      {
+        "version": "1.0.0-alpha"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.1 < 1.0.0-alpha.beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.beta < 1.0.0-beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta < 1.0.0-beta.2",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.2"
+        }
+      },
+      {
+        "version": "1.0.0-beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.2 < 1.0.0-beta.11",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.11"
+        }
+      },
+      {
+        "version": "1.0.0-beta.2"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.11 < 1.0.0-rc.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-rc.1"
+        }
+      },
+      {
+        "version": "1.0.0-beta.11"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-rc.1 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-rc.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0--1",
+      {
+        "version": {
+          "$vlt": "1.0.0--1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-1.0 < 1.0.0-1.-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1.-1"
+        }
+      },
+      {
+        "version": "1.0.0-1.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c < 1.2.3-a.b.c.d",
+      {
+        "version": {
+          "$vlt": "1.2.3-a.b.c.d"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "v0.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "v0.0.1"
+      },
+      true
+    ],
+    [
+      "version v1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "v1.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "v0.10.0"
+      },
+      true
+    ],
+    [
+      "version v0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "v0.99.0"
+      },
+      true
+    ],
+    [
+      "version v2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "v2.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > v0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "v0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > v0.0.0",
+      {
+        "version": {
+          "$vgt": "v0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > v0.9.9",
+      {
+        "version": {
+          "$vgt": "v0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > v0.9.0",
+      {
+        "version": {
+          "$vgt": "v0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > v0.10.0",
+      {
+        "version": {
+          "$vgt": "v0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > v1.2.3",
+      {
+        "version": {
+          "$vgt": "v1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-asdf",
+      {
+        "version": {
+          "$vgt": "1.2.3-asdf"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4-foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-4-foo"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5",
+      {
+        "version": {
+          "$vgt": "1.2.3-5"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3-5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5-Foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-5-Foo"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 3.0.0 > 2.7.2+asdf",
+      {
+        "version": {
+          "$vgt": "2.7.2+asdf"
+        }
+      },
+      {
+        "version": "3.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.10 > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.10"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a",
+      {
+        "version": {
+          "$vgt": "1.2.3-a"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c.10.d.5 > 1.2.3-a.b.c.5.d.100",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.b.c.5.d.100"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c.10.d.5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r2 > 1.2.3-r100",
+      {
+        "version": {
+          "$vgt": "1.2.3-r100"
+        }
+      },
+      {
+        "version": "1.2.3-r2"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r100 > 1.2.3-R2",
+      {
+        "version": {
+          "$vgt": "1.2.3-R2"
+        }
+      },
+      {
+        "version": "1.2.3-r100"
+      },
+      true
+    ],
+    [
+      "version a.b.c.d.e.f > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "a.b.c.d.e.f"
+      },
+      true
+    ],
+    [
+      "version 10.0.0 > 9.0.0",
+      {
+        "version": {
+          "$vgt": "9.0.0"
+        }
+      },
+      {
+        "version": "10.0.0"
+      },
+      true
+    ],
+    [
+      "version 10000.0.0 > 9999.0.0",
+      {
+        "version": {
+          "$vgt": "9999.0.0"
+        }
+      },
+      {
+        "version": "10000.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-0 == v1.2.3-0",
+      {
+        "version": {
+          "$veq": "v1.2.3-0"
+        }
+      },
+      {
+        "version": "1.2.3-0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == 1.2.3-1",
+      {
+        "version": {
+          "$veq": "1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == v1.2.3-1",
+      {
+        "version": {
+          "$veq": "v1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == 1.2.3-beta",
+      {
+        "version": {
+          "$veq": "1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == v1.2.3-beta",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == 1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == v1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1-2.3+build99",
+      {
+        "version": {
+          "$veq": "1-2.3+build99"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3.4 == 1.2.3-4",
+      {
+        "version": {
+          "$veq": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3.4"
+      },
+      true
+    ],
+    [
+      "$or pass but second condition fail",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 1
+      },
+      false
+    ],
+    [
+      "$or and second condition both pass",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 2
+      },
+      true
+    ],
+    [
+      "$and condition pass but $or fail",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2
+      },
+      false
+    ],
+    [
+      "$and and $or both pass",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2,
+        "empty": 1
+      },
+      true
     ]
   ],
-  "versionCompare": {
-    "lt": [
-      ["0.9.99", "1.0.0", true],
-      ["0.9.0", "0.10.0", true],
-      ["1.0.0-0.0", "1.0.0-0.0.0", true],
-      ["1.0.0-9999", "1.0.0--", true],
-      ["1.0.0-99", "1.0.0-100", true],
-      ["1.0.0-alpha", "1.0.0-alpha.1", true],
-      ["1.0.0-alpha.1", "1.0.0-alpha.beta", true],
-      ["1.0.0-alpha.beta", "1.0.0-beta", true],
-      ["1.0.0-beta", "1.0.0-beta.2", true],
-      ["1.0.0-beta.2", "1.0.0-beta.11", true],
-      ["1.0.0-beta.11", "1.0.0-rc.1", true],
-      ["1.0.0-rc.1", "1.0.0", true],
-      ["1.0.0-0", "1.0.0--1", true],
-      ["1.0.0-0", "1.0.0-1", true],
-      ["1.0.0-1.0", "1.0.0-1.-1", true]
-    ],
-    "gt": [
-      ["0.0.0", "0.0.0-foo", true],
-      ["0.0.1", "0.0.0", true],
-      ["1.0.0", "0.9.9", true],
-      ["0.10.0", "0.9.0", true],
-      ["0.99.0", "0.10.0", true],
-      ["2.0.0", "1.2.3", true],
-      ["v0.0.0", "0.0.0-foo", true],
-      ["v0.0.1", "0.0.0", true],
-      ["v1.0.0", "0.9.9", true],
-      ["v0.10.0", "0.9.0", true],
-      ["v0.99.0", "0.10.0", true],
-      ["v2.0.0", "1.2.3", true],
-      ["0.0.0", "v0.0.0-foo", true],
-      ["0.0.1", "v0.0.0", true],
-      ["1.0.0", "v0.9.9", true],
-      ["0.10.0", "v0.9.0", true],
-      ["0.99.0", "v0.10.0", true],
-      ["2.0.0", "v1.2.3", true],
-      ["1.2.3", "1.2.3-asdf", true],
-      ["1.2.3", "1.2.3-4", true],
-      ["1.2.3", "1.2.3-4-foo", true],
-      ["1.2.3-5-foo", "1.2.3-5", true],
-      ["1.2.3-5", "1.2.3-4", true],
-      ["1.2.3-5-foo", "1.2.3-5-Foo", true],
-      ["3.0.0", "2.7.2+asdf", true],
-      ["1.2.3-a.10", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a", true],
-      ["1.2.3-a.b.c", "1.2.3-a.b.c.d", false],
-      ["1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100", true],
-      ["1.2.3-r2", "1.2.3-r100", true],
-      ["1.2.3-r100", "1.2.3-R2", true],
-      ["a.b.c.d.e.f", "1.2.3", true],
-      ["10.0.0", "9.0.0", true],
-      ["10000.0.0", "9999.0.0", true]
-    ],
-    "eq": [
-      ["1.2.3", "1.2.3", true],
-      ["1.2.3", "v1.2.3", true],
-      ["1.2.3-0", "v1.2.3-0", true],
-      ["1.2.3-1", "1.2.3-1", true],
-      ["1.2.3-1", "v1.2.3-1", true],
-      ["1.2.3-beta", "1.2.3-beta", true],
-      ["1.2.3-beta", "v1.2.3-beta", true],
-      ["1.2.3-beta+build", "1.2.3-beta+otherbuild", true],
-      ["1.2.3-beta+build", "v1.2.3-beta+otherbuild", true],
-      ["1-2-3", "1.2.3", true],
-      ["1-2-3", "1-2.3+build99", true],
-      ["1-2-3", "v1.2.3", true],
-      ["1.2.3.4", "1.2.3-4", true]
-    ]
-  },
   "hash": [
     ["", "a", 1, 0.22],
     ["", "b", 1, 0.077],
@@ -2409,6 +3147,33 @@
         "value": 2,
         "on": true,
         "off": false,
+        "source": "defaultValue"
+      }
+    ],
+    [
+      "force rules - coverage 0",
+      {
+        "attributes": {
+          "id": "d0bc0a5a"
+        },
+        "features": {
+          "8d156": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "8d156",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
         "source": "defaultValue"
       }
     ],

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.6.0",
+  "specVersion": "0.7.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -2828,6 +2828,78 @@
         "empty": 1
       },
       true
+    ],
+    [
+      "$inGroup passes for member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for non-member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 5 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for unknown group id",
+      {
+        "id": { "$inGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup fails for member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for non-member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 5 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for unknown group id",
+      {
+        "id": { "$notInGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup passes for properly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "2" },
+      true,
+      { "group_id": [1, "2", 3] }
+    ],
+    [
+      "$inGroup fails for improperly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "3" },
+      false,
+      { "group_id": [1, "2", 3] }
     ]
   ],
   "hash": [
@@ -4375,6 +4447,58 @@
       }
     ],
     [
+      "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [0, 1],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": { "value": 0 },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": { "memberType": "basic" },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite"
+      }
+    ],
+    [
       "Prerequisite cycle detected, break",
       {
         "attributes": {
@@ -4417,6 +4541,151 @@
         "on": false,
         "off": true,
         "source": "cyclicPrerequisite"
+      }
+    ],
+    [
+      "Multiple references to same prerequisite, do not break",
+      {
+        "attributes": {
+          "id": "123",
+          "browser": "edge"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "$ne": false },
+                    "gate": true
+                  },
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "browser": "safari"
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "C"
+              },
+              {
+                "condition": {
+                  "browser": { "$ne": "safari" }
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "T"
+              }
+            ]
+          },
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "T",
+        "on": true,
+        "off": false,
+        "source": "force"
+      }
+    ],
+    [
+      "SavedGroups correctly pulled from context for force rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_force_rule": {
+            "defaultValue": false,
+            "rules": [
+              {
+                "force": true,
+                "condition": { "id": { "$inGroup": "group_id" } }
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_force_rule",
+      { "value": true, "on": true, "off": false, "source": "force" }
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_experiment_rule": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "condition": { "id": { "$inGroup": "group_id" } },
+                "hashVersion": 2,
+                "variations": [1, 2],
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_experiment_rule",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
+          "ranges": [
+            [0, 0.5],
+            [0.5, 1.0]
+          ],
+          "key": "experiment"
+        },
+        "experimentResult": {
+          "featureId": "inGroup_experiment_rule",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": 123,
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.1736,
+          "stickyBucketUsed": false
+        }
       }
     ]
   ],
@@ -5300,6 +5569,23 @@
       0,
       false,
       false
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment",
+      {
+        "attributes": { "id": "4" },
+        "savedGroups": { "group_id": ["4", "5", "6"] }
+      },
+      {
+        "key": "group-filtered-test",
+        "condition": {
+          "id": { "$inGroup": "group_id" }
+        },
+        "variations": [0, 1, 2]
+      },
+      0,
+      true,
+      true
     ]
   ],
   "chooseVariation": [


### PR DESCRIPTION
### New features support

- Add support to `savedGroups` functionality
  - Add support to `$inGroup` and `$notInGroup` operators
  - Updated caching to also cache `savedGroups` and not just `features` 
- Add support to `ruleId`

### Bug fixes

- Fix overly eager exit when evaluating prereqs
- Fix bug in targeting condition when checking if non-existent attribute is equal to false

### Changes

- Renamed `loadFeatures` -> `initialize` as it now also handles savedGroups in addition of features
  - Kept `loadFeatures` for backwards compatibility, but it is now marked as deprecated