### PR TITLE
fix: sticky bucket incorrectly treats variation key '0' as falsy

### DIFF
--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -3,7 +3,6 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use Growthbook\Condition;
-use Growthbook\ExperimentResult;
 use Growthbook\FeatureResult;
 use Growthbook\Growthbook;
 use Growthbook\InlineExperiment;


### PR DESCRIPTION
This PR addresses this issue: #46 


- Fix bug in getStickyBucketVariation() where variation key '0' was incorrectly treated as a falsy value, causing the method to return -1 instead of the correct variation index
- Change condition from 'if (!)' to 'if ( === null)' to properly distinguish between null (no assignment) and '0' (valid variation)
- All existing tests continue to pass, ensuring no regressions

Fixes issue where users assigned to variation 0 in sticky bucket experiments would incorrectly receive -1 (not in experiment) instead of the correct variation result.