### PR TITLE
Remove type to make tests happy

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -132,7 +132,7 @@ class Condition
      * @param string $path
      * @return mixed
      */
-    private static function getPath(array $attributes, string $path): mixed
+    private static function getPath(array $attributes, string $path)
     {
         $current = $attributes;
         $parts = explode(".", $path);


### PR DESCRIPTION
The `mixed` return type is not playing along nicely with certain configurations. So reverting one part of the work done in #43 to keep all the scenarios working.