### PR TITLE
feat: add case-insensitive and regex operators support

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -151,8 +151,13 @@ class Condition
      * @param array<string,mixed> $savedGroups
      * @return bool
      */
-    private static function evalConditionValue($conditionValue, $attributeValue, array $savedGroups): bool
+    private static function evalConditionValue($conditionValue, $attributeValue, array $savedGroups, bool $insensitive = false): bool
     {
+        // Simple equality comparison with optional case-insensitivity
+        if ($insensitive && is_string($conditionValue) && is_string($attributeValue)) {
+            return strcasecmp($conditionValue, $attributeValue) === 0;
+        }
+
         if (is_array($conditionValue) && static::isOperatorObject($conditionValue)) {
             foreach ($conditionValue as $key => $value) {
                 if (!static::evalOperatorCondition($key, $attributeValue, $value, $savedGroups)) {
@@ -205,7 +210,7 @@ class Condition
             if ($val2 === null) {
                 $val2 = 0;
             } else {
-                $val2 = (float)$val2;
+                $val2 = (float) $val2;
             }
         }
 
@@ -213,7 +218,7 @@ class Condition
             if ($val1 === null) {
                 $val1 = 0;
             } else {
-                $val1 = (float)$val1;
+                $val1 = (float) $val1;
             }
         }
 
@@ -261,23 +266,29 @@ class Condition
             case '$vlte':
                 return static::parseVersionString($attributeValue) <= static::parseVersionString($conditionValue);
             case '$regex':
-                return @preg_match('/' . $conditionValue . '/', $attributeValue ?? '') === 1;
+                return static::regexMatch($conditionValue, $attributeValue) === 1;
+            case '$regexi':
+                return static::regexMatch($conditionValue, $attributeValue, true) === 1;
             case '$in':
                 if (!is_array($conditionValue)) {
                     return false;
                 }
-                if (!is_array($attributeValue)) {
-                    $attributeValue = [$attributeValue];
+                return static::isIn($attributeValue, $conditionValue, false);
+            case '$ini':
+                if (!is_array($conditionValue)) {
+                    return false;
                 }
-                return array_intersect($attributeValue, $conditionValue) !== [];
+                return static::isIn($attributeValue, $conditionValue, true);
             case '$nin':
                 if (!is_array($conditionValue)) {
                     return false;
                 }
-                if (!is_array($attributeValue)) {
-                    $attributeValue = [$attributeValue];
+                return !static::isIn($attributeValue, $conditionValue, false);
+            case '$nini':
+                if (!is_array($conditionValue)) {
+                    return false;
                 }
-                return array_intersect($attributeValue, $conditionValue) === [];
+                return !static::isIn($attributeValue, $conditionValue, true);
             case '$inGroup':
                 if (!array_key_exists($conditionValue, $savedGroups)) {
                     return false;
@@ -309,19 +320,12 @@ class Condition
                 if (!is_array($attributeValue) || !is_array($conditionValue)) {
                     return false;
                 }
-                foreach ($conditionValue as $a) {
-                    $pass = false;
-                    foreach ($attributeValue as $b) {
-                        if (static::evalConditionValue($a, $b, $savedGroups)) {
-                            $pass = true;
-                            break;
-                        }
-                    }
-                    if (!$pass) {
-                        return false;
-                    }
+                return static::isInAll($attributeValue, $conditionValue, $savedGroups, false);
+            case '$alli':
+                if (!is_array($attributeValue) || !is_array($conditionValue)) {
+                    return false;
                 }
-                return true;
+                return static::isInAll($attributeValue, $conditionValue, $savedGroups, true);
             case '$exists':
                 if (!$conditionValue) {
                     return $attributeValue === null;
@@ -361,5 +365,72 @@ class Condition
         }, $parts);
 
         return implode('-', $parts);
+    }
+
+    /**
+     * @param mixed $attributeValue
+     * @param array<mixed> $conditionValue
+     * @param bool $insensitive
+     * @return bool
+     */
+    private static function isIn($attributeValue, array $conditionValue, bool $insensitive = false): bool
+    {
+        if (!is_array($attributeValue)) {
+            $attributeValue = [$attributeValue];
+        }
+
+        foreach ($attributeValue as $actual) {
+            foreach ($conditionValue as $expected) {
+                if ($insensitive && is_string($actual) && is_string($expected)) {
+                    if (strcasecmp($actual, $expected) === 0) {
+                        return true;
+                    }
+                } elseif ($actual === $expected) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param array<mixed> $attributeValue
+     * @param array<mixed> $conditionValue
+     * @param array<string,mixed> $savedGroups
+     * @param bool $insensitive
+     * @return bool
+     */
+    private static function isInAll($attributeValue, $conditionValue, $savedGroups, bool $insensitive = false): bool
+    {
+        foreach ($conditionValue as $a) {
+            $pass = false;
+            foreach ($attributeValue as $b) {
+                if (static::evalConditionValue($a, $b, $savedGroups, $insensitive)) {
+                    $pass = true;
+                    break;
+                }
+            }
+            if (!$pass) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Runs preg_match for a condition regex pattern against an attribute value.
+     * Returns 1 (match), 0 (no match) or false (invalid/incomparable pattern),
+     * mirroring preg_match's own return values so callers can distinguish a
+     * real "no match" from an unmatchable pattern.
+     *
+     * @param mixed $pattern
+     * @param mixed $value
+     * @param bool $caseInsensitive
+     * @return int|false
+     */
+    private static function regexMatch($pattern, $value, bool $caseInsensitive = false)
+    {
+        $modifiers = $caseInsensitive ? 'i' : '';
+        return @preg_match('/' . $pattern . '/' . $modifiers, $value ?? '');
     }
 }

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1228,4 +1228,32 @@ final class GrowthbookTest extends TestCase
         $exp = new InlineExperiment("test-exp", [0, 1]);
         $gb->runInlineExperiment($exp);
     }
+
+    /**
+     * @dataProvider regexOperatorProvider
+     * @param string $operator
+     * @param string $attributeValue
+     * @param string $pattern
+     * @param bool $expected
+     */
+    public function testRegexOperators(string $operator, string $attributeValue, string $pattern, bool $expected): void
+    {
+        $condition = ["name" => [$operator => $pattern]];
+        $this->assertSame($expected, Condition::evalCondition(["name" => $attributeValue], $condition, []));
+    }
+
+    /**
+     * @return array<int|string,mixed[]>
+     */
+    public function regexOperatorProvider(): array
+    {
+        return [
+            '$regex - match' => ['$regex', 'hello', 'ell', true],
+            '$regex - no match' => ['$regex', 'hello', 'xyz', false],
+            '$regex - invalid pattern' => ['$regex', 'hello', '[', false],
+            '$regexi - match different case' => ['$regexi', 'Hello', 'ell', true],
+            '$regexi - no match' => ['$regexi', 'Hello', 'xyz', false],
+            '$regexi - invalid pattern' => ['$regexi', 'Hello', '[', false],
+        ];
+    }
 }

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -482,6 +482,18 @@
       false
     ],
     [
+      "$in - fail (case sensitive mismatch)",
+      {
+        "country": {
+          "$in": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
       "$nin - pass",
       {
         "num": {
@@ -576,6 +588,198 @@
         "tags": []
       },
       true
+    ],
+    [
+      "$nin - pass (case sensitive mismatch)",
+      {
+        "country": {
+          "$nin": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (case insensitive match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$ini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      true
+    ],
+    [
+      "$ini - pass (mixed case)",
+      {
+        "country": {
+          "$ini": ["Us", "Uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - fail (no match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      false
+    ],
+    [
+      "$ini - array pass 1",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      true
+    ],
+    [
+      "$ini - array pass 2",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      true
+    ],
+    [
+      "$ini - array fail",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      false
+    ],
+    [
+      "$ini - not array",
+      {
+        "num": {
+          "$ini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$nini - pass (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      true
+    ],
+    [
+      "$nini - fail (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
+      "$nini - fail (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$nini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      false
+    ],
+    [
+      "$nini - array pass",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      true
+    ],
+    [
+      "$nini - array fail 1",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      false
+    ],
+    [
+      "$nini - array fail 2",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      false
+    ],
+    [
+      "$nini - not array",
+      {
+        "num": {
+          "$nini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
     ],
     [
       "$elemMatch - pass - flat arrays",
@@ -750,6 +954,54 @@
       {
         "userAgent": {
           "$regex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$regex - fail (case sensitive mismatch)",
+      {
+        "userAgent": {
+          "$regex": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
         }
       },
       {
@@ -1435,6 +1687,78 @@
       {
         "tags": {
           "$all": ["one", "three"]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
+      "$all - fail (case sensitive mismatch)",
+      {
+        "tags": {
+          "$all": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      false
+    ],
+    [
+      "$alli - pass (case insensitive match)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (uppercase pattern, lowercase value)",
+      {
+        "tags": {
+          "$alli": ["ONE", "THREE"]
+        }
+      },
+      {
+        "tags": ["one", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (mixed case)",
+      {
+        "tags": {
+          "$alli": ["One", "Three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - fail (case insensitive, missing value)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "four"]
+      },
+      false
+    ],
+    [
+      "$alli - fail not array",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
         }
       },
       {
@@ -3397,6 +3721,62 @@
         "value": 2,
         "on": true,
         "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 includes user",
+      {
+        "attributes": {
+          "id": "user2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 excludes user that v1 would include",
+      {
+        "attributes": {
+          "id": "user3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
         "source": "defaultValue",
         "ruleId": ""
       }
@@ -6407,6 +6787,249 @@
           },
           "attributeName": "id",
           "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": true,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "deviceId||d123": {
+          "assignments": { "feature-exp__3": "2" },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "skips assignment when sticky bucket version < experiment.minBucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__2": "2"
+          }
+        }
+      ],
+      "exp1",
+      null,
+      {
+        "deviceId||d123": {
+          "assignments": { "feature-exp__2": "2" },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__4": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "1",
+            "feature-exp__4": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 4,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2",
+            "feature-exp__4": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
         }
       }
     ],


### PR DESCRIPTION
Added new operators:

`$ini`/ `$nini` — case-insensitive version of `$in` / `$nin`
`$alli` — case-insensitive version of `$all`
`$regexi` — case-insensitive regex match

All operators match the TypeScript SDK reference implementation.