### PR TITLE
feat!: make with* methods immutable (2.0.0)

### DIFF
--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -178,11 +178,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param array<string,mixed> $attributes
      * @return static
-     * @deprecated Use setAttributes() instead. withAttributes() will become immutable in 2.0.0.
      */
     public function withAttributes(array $attributes): static
     {
-        return $this->setAttributes($attributes);
+        $self = clone $this;
+        $self->setAttributes($attributes);
+
+        return $self;
     }
 
     /**
@@ -199,11 +201,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param array<string,mixed> $savedGroups
      * @return static
-     * @deprecated Use setSavedGroups() instead. withSavedGroups() will become immutable in 2.0.0.
      */
     public function withSavedGroups(array $savedGroups): static
     {
-        return $this->setSavedGroups($savedGroups);
+        $self = clone $this;
+        $self->setSavedGroups($savedGroups);
+
+        return $self;
     }
 
     /**
@@ -220,11 +224,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param callable|null $trackingCallback
      * @return static
-     * @deprecated Use setTrackingCallback() instead. withTrackingCallback() will become immutable in 2.0.0.
      */
     public function withTrackingCallback($trackingCallback): static
     {
-        return $this->setTrackingCallback($trackingCallback);
+        $self = clone $this;
+        $self->setTrackingCallback($trackingCallback);
+
+        return $self;
     }
 
     /**
@@ -249,11 +255,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param array<string,Feature<mixed>|mixed> $features
      * @return static
-     * @deprecated Use setFeatures() instead. withFeatures() will become immutable in 2.0.0.
      */
     public function withFeatures(array $features): static
     {
-        return $this->setFeatures($features);
+        $self = clone $this;
+        $self->setFeatures($features);
+
+        return $self;
     }
 
     /**
@@ -269,11 +277,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param array<string,int> $forcedVariations
      * @return static
-     * @deprecated Use setForcedVariations() instead. withForcedVariations() will become immutable in 2.0.0.
      */
     public function withForcedVariations(array $forcedVariations): static
     {
-        return $this->setForcedVariations($forcedVariations);
+        $self = clone $this;
+        $self->setForcedVariations($forcedVariations);
+
+        return $self;
     }
 
     /**
@@ -289,11 +299,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param array<string, FeatureResult<mixed>> $forcedFeatures
      * @return static
-     * @deprecated Use setForcedFeatures() instead. withForcedFeatures() will become immutable in 2.0.0.
      */
     public function withForcedFeatures(array $forcedFeatures): static
     {
-        return $this->setForcedFeatures($forcedFeatures);
+        $self = clone $this;
+        $self->setForcedFeatures($forcedFeatures);
+
+        return $self;
     }
 
     /**
@@ -309,11 +321,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param string $url
      * @return static
-     * @deprecated Use setUrl() instead. withUrl() will become immutable in 2.0.0.
      */
     public function withUrl(string $url): static
     {
-        return $this->setUrl($url);
+        $self = clone $this;
+        $self->setUrl($url);
+
+        return $self;
     }
 
     /**
@@ -327,12 +341,13 @@ class Growthbook implements LoggerAwareInterface
     /**
      * @param LoggerInterface|null $logger
      * @return static
-     * @deprecated Use setLogger() instead. withLogger() will become immutable in 2.0.0.
      */
     public function withLogger(?LoggerInterface $logger = null): static
     {
-        $this->setLogger($logger);
-        return $this;
+        $self = clone $this;
+        $self->setLogger($logger);
+
+        return $self;
     }
 
     /**
@@ -353,11 +368,13 @@ class Growthbook implements LoggerAwareInterface
      * @param \Psr\Http\Client\ClientInterface $client
      * @param \Psr\Http\Message\RequestFactoryInterface $requestFactory
      * @return static
-     * @deprecated Use setHttpClient() instead. withHttpClient() will become immutable in 2.0.0.
      */
     public function withHttpClient(\Psr\Http\Client\ClientInterface $client, \Psr\Http\Message\RequestFactoryInterface $requestFactory): static
     {
-        return $this->setHttpClient($client, $requestFactory);
+        $self = clone $this;
+        $self->setHttpClient($client, $requestFactory);
+
+        return $self;
     }
 
     /**
@@ -377,11 +394,13 @@ class Growthbook implements LoggerAwareInterface
      *
      * @param int $seconds Timeout in seconds (default: 2)
      * @return static
-     * @deprecated Use setApiTimeout() instead. withApiTimeout() will become immutable in 2.0.0.
      */
     public function withApiTimeout(int $seconds): static
     {
-        return $this->setApiTimeout($seconds);
+        $self = clone $this;
+        $self->setApiTimeout($seconds);
+
+        return $self;
     }
 
     /**
@@ -401,11 +420,13 @@ class Growthbook implements LoggerAwareInterface
      *
      * @param int $seconds Connection timeout in seconds (default: 2)
      * @return static
-     * @deprecated Use setApiConnectTimeout() instead. withApiConnectTimeout() will become immutable in 2.0.0.
      */
     public function withApiConnectTimeout(int $seconds): static
     {
-        return $this->setApiConnectTimeout($seconds);
+        $self = clone $this;
+        $self->setApiConnectTimeout($seconds);
+
+        return $self;
     }
 
     /**
@@ -427,11 +448,13 @@ class Growthbook implements LoggerAwareInterface
      * @param \Psr\SimpleCache\CacheInterface $cache
      * @param int|null                       $ttl
      * @return static
-     * @deprecated Use setCache() instead. withCache() will become immutable in 2.0.0.
      */
     public function withCache(\Psr\SimpleCache\CacheInterface $cache, ?int $ttl = null): static
     {
-        return $this->setCache($cache, $ttl);
+        $self = clone $this;
+        $self->setCache($cache, $ttl);
+
+        return $self;
     }
 
     /**
@@ -451,11 +474,13 @@ class Growthbook implements LoggerAwareInterface
      * @param StickyBucketService $stickyBucketService
      * @param array<string>|null  $stickyBucketIdentifierAttributes
      * @return static
-     * @deprecated Use setStickyBucketing() instead. withStickyBucketing() will become immutable in 2.0.0.
      */
     public function withStickyBucketing(StickyBucketService $stickyBucketService, ?array $stickyBucketIdentifierAttributes): static
     {
-        return $this->setStickyBucketing($stickyBucketService, $stickyBucketIdentifierAttributes);
+        $self = clone $this;
+        $self->setStickyBucketing($stickyBucketService, $stickyBucketIdentifierAttributes);
+
+        return $self;
     }
 
     /**

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -992,12 +992,13 @@ final class GrowthbookTest extends TestCase
         $this->assertSame(1, $actualFeatures['feature-1']->defaultValue);
         $this->assertSame(2, $actualFeatures['feature-2']->defaultValue);
 
-        // Test that with* methods return a new instance (immutable)
+        // Test that with* methods return a new instance (immutability)
         $newAttributes = ['id' => 999];
         $newGb = $gb->withAttributes($newAttributes);
 
-        $this->assertNotSame($gb, $newGb); // Should be a new instance
-        $this->assertSame($newAttributes, $newGb->getAttributes()); // New instance has updated value
+        $this->assertNotSame($gb, $newGb); // Should be different instances
+        $this->assertSame($attributes, $gb->getAttributes()); // Original unchanged
+        $this->assertSame($newAttributes, $newGb->getAttributes()); // New has updated value
     }
 
     /**
@@ -1005,24 +1006,27 @@ final class GrowthbookTest extends TestCase
      */
     public function testWithMethodsImmutability(): void
     {
-        $gb = Growthbook::create()
+        $originalGb = Growthbook::create()
             ->withAttributes(['id' => 1])
             ->withFeatures(['test' => ['defaultValue' => true]])
             ->withUrl('/original');
 
-        // Test each with* method returns a new instance (immutable behavior)
-        $result = $gb->withAttributes(['id' => 2]);
-        $this->assertNotSame($gb, $result);
-        $this->assertSame(['id' => 1], $gb->getAttributes()); // Original unchanged
-        $this->assertSame(['id' => 2], $result->getAttributes()); // New instance updated
+        // Test each with* method creates a new instance
+        $newGb1 = $originalGb->withAttributes(['id' => 2]);
+        $this->assertNotSame($originalGb, $newGb1);
+        $this->assertSame(['id' => 1], $originalGb->getAttributes());
+        $this->assertSame(['id' => 2], $newGb1->getAttributes());
 
-        $result2 = $gb->withFeatures(['new-feature' => ['defaultValue' => false]]);
-        $this->assertNotSame($gb, $result2);
+        $newGb2 = $originalGb->withFeatures(['new-feature' => ['defaultValue' => false]]);
+        $this->assertNotSame($originalGb, $newGb2);
+        $this->assertNotSame($newGb1, $newGb2);
 
-        $result3 = $gb->withUrl('/new-url');
-        $this->assertNotSame($gb, $result3);
-        $this->assertSame('/original', $gb->getUrl()); // Original unchanged
-        $this->assertSame('/new-url', $result3->getUrl()); // New instance updated
+        $newGb3 = $originalGb->withUrl('/new-url');
+        $this->assertNotSame($originalGb, $newGb3);
+        $this->assertNotSame($newGb1, $newGb3);
+        $this->assertNotSame($newGb2, $newGb3);
+        $this->assertSame('/original', $originalGb->getUrl());
+        $this->assertSame('/new-url', $newGb3->getUrl());
     }
 
     public function testDefaultTimeoutValues(): void
@@ -1082,18 +1086,19 @@ final class GrowthbookTest extends TestCase
         $this->assertEquals(1, $prop->getValue($gb));
     }
 
-    public function testWithApiTimeoutImmutability(): void
+    public function testWithApiTimeoutReturnsNewInstance(): void
     {
-        $gb = new Growthbook();
-        $result = $gb->withApiTimeout(10);
+        $gb1 = new Growthbook();
+        $gb2 = $gb1->withApiTimeout(10);
 
-        $this->assertNotSame($gb, $result);
+        $this->assertNotSame($gb1, $gb2);
 
-        $ref = new \ReflectionClass($result);
+        $ref = new \ReflectionClass($gb2);
         $timeout = $ref->getProperty('apiTimeout');
         $timeout->setAccessible(true);
 
-        $this->assertEquals(10, $timeout->getValue($result));
+        $this->assertEquals(2, $timeout->getValue($gb1)); 
+        $this->assertEquals(10, $timeout->getValue($gb2));
     }
 
     public function testCustomHttpClientIsNotOverridden(): void

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -992,35 +992,37 @@ final class GrowthbookTest extends TestCase
         $this->assertSame(1, $actualFeatures['feature-1']->defaultValue);
         $this->assertSame(2, $actualFeatures['feature-2']->defaultValue);
 
-        // Test that with* methods return the same instance (mutable, backward compatible)
+        // Test that with* methods return a new instance (immutable)
         $newAttributes = ['id' => 999];
         $newGb = $gb->withAttributes($newAttributes);
 
-        $this->assertSame($gb, $newGb); // Should be the same instance
-        $this->assertSame($newAttributes, $gb->getAttributes()); // Original updated in place
+        $this->assertNotSame($gb, $newGb); // Should be a new instance
+        $this->assertSame($newAttributes, $newGb->getAttributes()); // New instance has updated value
     }
 
     /**
      * @return void
      */
-    public function testWithMethodsMutability(): void
+    public function testWithMethodsImmutability(): void
     {
         $gb = Growthbook::create()
             ->withAttributes(['id' => 1])
             ->withFeatures(['test' => ['defaultValue' => true]])
             ->withUrl('/original');
 
-        // Test each with* method mutates the same instance (backward compatible behavior)
+        // Test each with* method returns a new instance (immutable behavior)
         $result = $gb->withAttributes(['id' => 2]);
-        $this->assertSame($gb, $result);
-        $this->assertSame(['id' => 2], $gb->getAttributes());
+        $this->assertNotSame($gb, $result);
+        $this->assertSame(['id' => 1], $gb->getAttributes()); // Original unchanged
+        $this->assertSame(['id' => 2], $result->getAttributes()); // New instance updated
 
         $result2 = $gb->withFeatures(['new-feature' => ['defaultValue' => false]]);
-        $this->assertSame($gb, $result2);
+        $this->assertNotSame($gb, $result2);
 
         $result3 = $gb->withUrl('/new-url');
-        $this->assertSame($gb, $result3);
-        $this->assertSame('/new-url', $gb->getUrl());
+        $this->assertNotSame($gb, $result3);
+        $this->assertSame('/original', $gb->getUrl()); // Original unchanged
+        $this->assertSame('/new-url', $result3->getUrl()); // New instance updated
     }
 
     public function testDefaultTimeoutValues(): void
@@ -1080,18 +1082,18 @@ final class GrowthbookTest extends TestCase
         $this->assertEquals(1, $prop->getValue($gb));
     }
 
-    public function testWithApiTimeoutMutatesInstance(): void
+    public function testWithApiTimeoutImmutability(): void
     {
         $gb = new Growthbook();
         $result = $gb->withApiTimeout(10);
 
-        $this->assertSame($gb, $result);
+        $this->assertNotSame($gb, $result);
 
-        $ref = new \ReflectionClass($gb);
+        $ref = new \ReflectionClass($result);
         $timeout = $ref->getProperty('apiTimeout');
         $timeout->setAccessible(true);
 
-        $this->assertEquals(10, $timeout->getValue($gb));
+        $this->assertEquals(10, $timeout->getValue($result));
     }
 
     public function testCustomHttpClientIsNotOverridden(): void


### PR DESCRIPTION
## Summary

Implements the immutable API for `with*` methods as planned after v1.7.4.

## Changes

- All `with*` methods now return a new instance (immutable)
- `set*` methods remain mutable
- Updated tests to reflect new immutable behavior

## Breaking Change

`with*` methods no longer mutate `$this`. Users were warned via `@deprecated` 
in v1.7.4. See release notes for migration guide.