### PR TITLE
feat: implement tracking plugin system with built-in ingest plugin

### DIFF
--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -22,7 +22,7 @@ class GrowthBookTrackingPlugin implements Plugin
     public const DEFAULT_INGESTOR_HOST = "https://us1.gb-ingest.com";
     public const DEFAULT_BATCH_SIZE    = 100;
 
-    private const SDK_VERSION = "2.0.0";
+    private const PACKAGE_NAME = "growthbook/growthbook";
 
     private string $ingestorHost;
     private int $batchSize;
@@ -129,8 +129,17 @@ class GrowthBookTrackingPlugin implements Plugin
     {
         return array_merge($userAttributes, [
             'sdk_language' => 'php',
-            'sdk_version'  => self::SDK_VERSION,
+            'sdk_version'  => self::sdkVersion(),
         ]);
+    }
+
+    private static function sdkVersion(): string
+    {
+        try {
+            return \Composer\InstalledVersions::getPrettyVersion(self::PACKAGE_NAME) ?? 'unknown';
+        } catch (\Throwable $e) {
+            return 'unknown';
+        }
     }
 
     /** Synchronously flush all buffered events. Safe to call multiple times. */
@@ -197,7 +206,7 @@ class GrowthBookTrackingPlugin implements Plugin
             $request = $factory
                 ->createRequest('POST', $url)
                 ->withHeader('Content-Type', 'application/json')
-                ->withHeader('User-Agent', 'growthbook-php-sdk/' . self::SDK_VERSION)
+                ->withHeader('User-Agent', 'growthbook-php-sdk/' . self::sdkVersion())
                 ->withBody($this->createStream($factory, $payload));
 
             $client->sendRequest($request);

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -83,35 +83,53 @@ class GrowthBookTrackingPlugin implements Plugin
     /**
      * @param InlineExperiment<mixed> $experiment
      * @param ExperimentResult<mixed> $result
+     * @param array<string,mixed>     $attributes
      */
-    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result, array $attributes): void
     {
         if (!$this->initialized) {
             return;
         }
         $this->enqueue([
-            'event'         => 'experiment_viewed',
-            'experimentKey' => $experiment->key,
-            'variationId'   => $result->variationId,
-            'hashAttribute' => $result->hashAttribute,
-            'hashValue'     => $result->hashValue,
+            'event_name' => 'Experiment Viewed',
+            'properties' => [
+                'experimentId' => $experiment->key,
+                'variationId'  => $result->variationId,
+            ],
+            'attributes' => $this->mergedAttributes($attributes),
         ]);
     }
 
     /**
      * @param FeatureResult<mixed> $result
+     * @param array<string,mixed>  $attributes
      */
-    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result, array $attributes): void
     {
         if (!$this->initialized) {
             return;
         }
         $this->enqueue([
-            'event'      => 'feature_evaluated',
-            'featureKey' => $featureKey,
-            'value'      => $result->value,
-            'source'     => $result->source,
-            'ruleId'     => $result->ruleId ?? null,
+            'event_name' => 'Feature Evaluated',
+            'properties' => [
+                'feature' => $featureKey,
+                'value'   => $result->value,
+                'source'  => $result->source,
+                'ruleId'  => $result->ruleId ?? null,
+            ],
+            'attributes' => $this->mergedAttributes($attributes),
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $userAttributes
+     * @return array<string,mixed>
+     */
+    private function mergedAttributes(array $userAttributes): array
+    {
+        return array_merge($userAttributes, [
+            'sdk_language' => 'php',
+            'sdk_version'  => self::SDK_VERSION,
         ]);
     }
 

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -203,11 +203,11 @@ class GrowthBookTrackingPlugin implements Plugin
                 return;
             }
 
-            /** @var \Psr\Http\Message\RequestInterface $request */
             $request = $factory->createRequest('POST', $url);
             $request = $request->withHeader('Content-Type', 'application/json');
             $request = $request->withHeader('User-Agent', 'growthbook-php-sdk/' . self::sdkVersion());
             $request = $request->withBody($this->createStream($factory, $payload));
+            \assert($request instanceof \Psr\Http\Message\RequestInterface);
 
             $client->sendRequest($request);
         } catch (\Throwable $e) {

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -203,11 +203,11 @@ class GrowthBookTrackingPlugin implements Plugin
                 return;
             }
 
-            $request = $factory
-                ->createRequest('POST', $url)
-                ->withHeader('Content-Type', 'application/json')
-                ->withHeader('User-Agent', 'growthbook-php-sdk/' . self::sdkVersion())
-                ->withBody($this->createStream($factory, $payload));
+            /** @var \Psr\Http\Message\RequestInterface $request */
+            $request = $factory->createRequest('POST', $url);
+            $request = $request->withHeader('Content-Type', 'application/json');
+            $request = $request->withHeader('User-Agent', 'growthbook-php-sdk/' . self::sdkVersion());
+            $request = $request->withBody($this->createStream($factory, $payload));
 
             $client->sendRequest($request);
         } catch (\Throwable $e) {

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Growthbook;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+
+/**
+ * Built-in plugin that batches experiment and feature evaluation events
+ * and POSTs them to the GrowthBook ingest endpoint.
+ *
+ * Endpoint:  POST {ingestorHost}/track
+ * Default host: https://us1.gb-ingest.com
+ * Body: { "client_key": "...", "events": [...] }
+ *
+ * Flush triggers:
+ *   - batch reaches $batchSize events
+ *   - close() is called (e.g. on object destruction or end of request)
+ */
+class GrowthBookTrackingPlugin implements Plugin
+{
+    public const DEFAULT_INGESTOR_HOST = "https://us1.gb-ingest.com";
+    public const DEFAULT_BATCH_SIZE    = 100;
+
+    private const SDK_VERSION = "2.0.0";
+
+    private string $ingestorHost;
+    private int $batchSize;
+    private string $clientKey = "";
+    private bool $initialized = false;
+    private bool $closed = false;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $queue = [];
+
+    private ?ClientInterface $httpClient;
+    private ?RequestFactoryInterface $requestFactory;
+
+    /** @var callable|null — overrides HTTP sending in tests */
+    private $sendHandler;
+
+    /**
+     * @param string                        $ingestorHost
+     * @param int                           $batchSize
+     * @param ClientInterface|null          $httpClient      PSR-18 client; auto-discovered when null
+     * @param RequestFactoryInterface|null  $requestFactory  PSR-17 factory; auto-discovered when null
+     */
+    public function __construct(
+        string $ingestorHost = self::DEFAULT_INGESTOR_HOST,
+        int $batchSize = self::DEFAULT_BATCH_SIZE,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null
+    ) {
+        $this->ingestorHost   = rtrim($ingestorHost, "/");
+        $this->batchSize      = max(1, $batchSize);
+        $this->httpClient     = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->sendHandler    = null;
+
+        // Flush remaining events when the PHP process shuts down (covers the
+        // case where close() is never called explicitly).
+        register_shutdown_function([$this, 'close']);
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin interface
+    // -------------------------------------------------------------------------
+
+    public function initialize(string $clientKey): void
+    {
+        if (empty($clientKey)) {
+            return;
+        }
+        $this->clientKey   = $clientKey;
+        $this->initialized = true;
+    }
+
+    /**
+     * @param InlineExperiment<mixed> $experiment
+     * @param ExperimentResult<mixed> $result
+     */
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    {
+        if (!$this->initialized) {
+            return;
+        }
+        $this->enqueue([
+            'event'         => 'experiment_viewed',
+            'experimentKey' => $experiment->key,
+            'variationId'   => $result->variationId,
+            'hashAttribute' => $result->hashAttribute,
+            'hashValue'     => $result->hashValue,
+        ]);
+    }
+
+    /**
+     * @param FeatureResult<mixed> $result
+     */
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    {
+        if (!$this->initialized) {
+            return;
+        }
+        $this->enqueue([
+            'event'      => 'feature_evaluated',
+            'featureKey' => $featureKey,
+            'value'      => $result->value,
+            'source'     => $result->source,
+            'ruleId'     => $result->ruleId ?? null,
+        ]);
+    }
+
+    /** Synchronously flush all buffered events. Safe to call multiple times. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->closed = true;
+        $this->flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function enqueue(array $event): void
+    {
+        $this->queue[] = $event;
+        if (count($this->queue) >= $this->batchSize) {
+            $this->flush();
+        }
+    }
+
+    private function flush(): void
+    {
+        if (empty($this->queue)) {
+            return;
+        }
+        $events      = $this->queue;
+        $this->queue = [];
+        $this->post($events);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $events
+     */
+    private function post(array $events): void
+    {
+        $payload = json_encode([
+            'client_key' => $this->clientKey,
+            'events'     => $events,
+        ]);
+
+        if ($payload === false) {
+            return;
+        }
+
+        // Test hook — bypasses real HTTP
+        if ($this->sendHandler !== null) {
+            ($this->sendHandler)($payload);
+            return;
+        }
+
+        try {
+            $client  = $this->resolveHttpClient();
+            $factory = $this->resolveRequestFactory();
+            if ($client === null || $factory === null) {
+                return;
+            }
+
+            $request = $factory
+                ->createRequest('POST', $this->ingestorHost . '/track')
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('User-Agent', 'growthbook-php-sdk/' . self::SDK_VERSION)
+                ->withBody($this->createStream($factory, $payload));
+
+            $client->sendRequest($request);
+        } catch (\Throwable $e) {
+            // never propagate network errors
+        }
+    }
+
+    private function resolveHttpClient(): ?ClientInterface
+    {
+        if ($this->httpClient !== null) {
+            return $this->httpClient;
+        }
+        try {
+            return \Http\Discovery\Psr18ClientDiscovery::find();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function resolveRequestFactory(): ?RequestFactoryInterface
+    {
+        if ($this->requestFactory !== null) {
+            return $this->requestFactory;
+        }
+        try {
+            return \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function createStream(RequestFactoryInterface $factory, string $body): \Psr\Http\Message\StreamInterface
+    {
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        return $streamFactory->createStream($body);
+    }
+
+    /**
+     * For testing only — injects a callable that receives the raw JSON payload
+     * instead of making a real HTTP request.
+     *
+     * @param callable(string):void $handler
+     */
+    public function setSendHandler(callable $handler): void
+    {
+        $this->sendHandler = $handler;
+    }
+}

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -13,19 +13,16 @@ use Psr\Http\Message\RequestFactoryInterface;
  * Default host: https://us1.gb-ingest.com
  * Body: [...events]  (plain JSON array)
  *
+ * Configure via GrowthBookTrackingPluginConfig.
  * Flush triggers:
- *   - batch reaches $batchSize events
+ *   - batch reaches config->batchSize events
  *   - close() is called (e.g. on object destruction or end of request)
  */
 class GrowthBookTrackingPlugin implements Plugin
 {
-    public const DEFAULT_INGESTOR_HOST = "https://us1.gb-ingest.com";
-    public const DEFAULT_BATCH_SIZE    = 100;
-
     private const PACKAGE_NAME = "growthbook/growthbook";
 
-    private string $ingestorHost;
-    private int $batchSize;
+    private GrowthBookTrackingPluginConfig $config;
     private string $clientKey = "";
     private bool $initialized = false;
     private bool $closed = false;
@@ -40,19 +37,16 @@ class GrowthBookTrackingPlugin implements Plugin
     private $sendHandler;
 
     /**
-     * @param string                        $ingestorHost
-     * @param int                           $batchSize
-     * @param ClientInterface|null          $httpClient      PSR-18 client; auto-discovered when null
-     * @param RequestFactoryInterface|null  $requestFactory  PSR-17 factory; auto-discovered when null
+     * @param GrowthBookTrackingPluginConfig|null $config         Plugin configuration; defaults used when null
+     * @param ClientInterface|null                $httpClient     PSR-18 client; auto-discovered when null
+     * @param RequestFactoryInterface|null        $requestFactory PSR-17 factory; auto-discovered when null
      */
     public function __construct(
-        string $ingestorHost = self::DEFAULT_INGESTOR_HOST,
-        int $batchSize = self::DEFAULT_BATCH_SIZE,
+        ?GrowthBookTrackingPluginConfig $config = null,
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null
     ) {
-        $this->ingestorHost   = rtrim($ingestorHost, "/");
-        $this->batchSize      = max(1, $batchSize);
+        $this->config         = $config ?? new GrowthBookTrackingPluginConfig();
         $this->httpClient     = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->sendHandler    = null;
@@ -162,7 +156,7 @@ class GrowthBookTrackingPlugin implements Plugin
     private function enqueue(array $event): void
     {
         $this->queue[] = $event;
-        if (count($this->queue) >= $this->batchSize) {
+        if (count($this->queue) >= $this->config->batchSize) {
             $this->flush();
         }
     }
@@ -188,7 +182,7 @@ class GrowthBookTrackingPlugin implements Plugin
             return;
         }
 
-        $url = $this->ingestorHost . '/track?client_key=' . rawurlencode($this->clientKey);
+        $url = $this->config->ingestorHost . '/track?client_key=' . rawurlencode($this->clientKey);
 
         // Test hook — bypasses real HTTP
         if ($this->sendHandler !== null) {

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -4,6 +4,8 @@ namespace Growthbook;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Built-in plugin that batches experiment and feature evaluation events
@@ -32,6 +34,7 @@ class GrowthBookTrackingPlugin implements Plugin
 
     private ?ClientInterface $httpClient;
     private ?RequestFactoryInterface $requestFactory;
+    private ?LoggerInterface $logger;
 
     /** @var callable|null — overrides HTTP sending in tests */
     private $sendHandler;
@@ -40,15 +43,18 @@ class GrowthBookTrackingPlugin implements Plugin
      * @param GrowthBookTrackingPluginConfig|null $config         Plugin configuration; defaults used when null
      * @param ClientInterface|null                $httpClient     PSR-18 client; auto-discovered when null
      * @param RequestFactoryInterface|null        $requestFactory PSR-17 factory; auto-discovered when null
+     * @param LoggerInterface|null                $logger         PSR-3 logger; errors are silently dropped when null
      */
     public function __construct(
         ?GrowthBookTrackingPluginConfig $config = null,
         ?ClientInterface $httpClient = null,
-        ?RequestFactoryInterface $requestFactory = null
+        ?RequestFactoryInterface $requestFactory = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->config         = $config ?? new GrowthBookTrackingPluginConfig();
         $this->httpClient     = $httpClient;
         $this->requestFactory = $requestFactory;
+        $this->logger         = $logger;
         $this->sendHandler    = null;
 
         // Flush remaining events when the PHP process shuts down (covers the
@@ -205,7 +211,11 @@ class GrowthBookTrackingPlugin implements Plugin
 
             $client->sendRequest($request);
         } catch (\Throwable $e) {
-            // never propagate network errors
+            if ($this->logger) {
+                $this->logger->log(LogLevel::ERROR, "GrowthBookTrackingPlugin: failed to send events", [
+                    "error" => $e->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -9,9 +9,9 @@ use Psr\Http\Message\RequestFactoryInterface;
  * Built-in plugin that batches experiment and feature evaluation events
  * and POSTs them to the GrowthBook ingest endpoint.
  *
- * Endpoint:  POST {ingestorHost}/track
+ * Endpoint:  POST {ingestorHost}/track?client_key={clientKey}
  * Default host: https://us1.gb-ingest.com
- * Body: { "client_key": "...", "events": [...] }
+ * Body: [...events]  (plain JSON array)
  *
  * Flush triggers:
  *   - batch reaches $batchSize events
@@ -155,18 +155,17 @@ class GrowthBookTrackingPlugin implements Plugin
      */
     private function post(array $events): void
     {
-        $payload = json_encode([
-            'client_key' => $this->clientKey,
-            'events'     => $events,
-        ]);
+        $payload = json_encode($events);
 
         if ($payload === false) {
             return;
         }
 
+        $url = $this->ingestorHost . '/track?client_key=' . rawurlencode($this->clientKey);
+
         // Test hook — bypasses real HTTP
         if ($this->sendHandler !== null) {
-            ($this->sendHandler)($payload);
+            ($this->sendHandler)($url, $payload);
             return;
         }
 
@@ -178,7 +177,7 @@ class GrowthBookTrackingPlugin implements Plugin
             }
 
             $request = $factory
-                ->createRequest('POST', $this->ingestorHost . '/track')
+                ->createRequest('POST', $url)
                 ->withHeader('Content-Type', 'application/json')
                 ->withHeader('User-Agent', 'growthbook-php-sdk/' . self::SDK_VERSION)
                 ->withBody($this->createStream($factory, $payload));
@@ -220,10 +219,10 @@ class GrowthBookTrackingPlugin implements Plugin
     }
 
     /**
-     * For testing only — injects a callable that receives the raw JSON payload
-     * instead of making a real HTTP request.
+     * For testing only — injects a callable that receives the request URL and
+     * raw JSON body instead of making a real HTTP request.
      *
-     * @param callable(string):void $handler
+     * @param callable(string $url, string $body):void $handler
      */
     public function setSendHandler(callable $handler): void
     {

--- a/src/GrowthBookTrackingPlugin.php
+++ b/src/GrowthBookTrackingPlugin.php
@@ -67,10 +67,6 @@ class GrowthBookTrackingPlugin implements Plugin
         $this->close();
     }
 
-    // -------------------------------------------------------------------------
-    // Plugin interface
-    // -------------------------------------------------------------------------
-
     public function initialize(string $clientKey): void
     {
         if (empty($clientKey)) {
@@ -151,10 +147,6 @@ class GrowthBookTrackingPlugin implements Plugin
         $this->closed = true;
         $this->flush();
     }
-
-    // -------------------------------------------------------------------------
-    // Internal
-    // -------------------------------------------------------------------------
 
     /**
      * @param array<string, mixed> $event

--- a/src/GrowthBookTrackingPluginConfig.php
+++ b/src/GrowthBookTrackingPluginConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Growthbook;
+
+class GrowthBookTrackingPluginConfig
+{
+    public const DEFAULT_INGESTOR_HOST = "https://us1.gb-ingest.com";
+    public const DEFAULT_BATCH_SIZE    = 100;
+
+    public string $ingestorHost;
+    public int $batchSize;
+
+    public function __construct(
+        string $ingestorHost = self::DEFAULT_INGESTOR_HOST,
+        int $batchSize = self::DEFAULT_BATCH_SIZE
+    ) {
+        $this->ingestorHost = rtrim($ingestorHost, "/");
+        $this->batchSize    = max(1, $batchSize);
+    }
+}

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -86,6 +86,9 @@ class Growthbook implements LoggerAwareInterface
     /** @var int */
     private $apiConnectTimeout = self::DEFAULT_API_TIMEOUT;
 
+    /** @var Plugin[] */
+    private $plugins = [];
+
     /**
      * @param array<string, mixed> $options
      * @return static
@@ -98,7 +101,7 @@ class Growthbook implements LoggerAwareInterface
     }
 
     /**
-     * @param array{enabled?:bool,logger?:\Psr\Log\LoggerInterface,url?:string,attributes?:array<string,mixed>,features?:array<string,mixed>,savedGroups?:array<string,array<string,mixed>>,forcedVariations?:array<string,int>,qaMode?:bool,trackingCallback?:callable,cache?:\Psr\SimpleCache\CacheInterface,httpClient?:\Psr\Http\Client\ClientInterface,requestFactory?:\Psr\Http\Message\RequestFactoryInterface,decryptionKey?:string,forcedFeatures?:array<string, FeatureResult<mixed>>} $options
+     * @param array{enabled?:bool,logger?:\Psr\Log\LoggerInterface,url?:string,attributes?:array<string,mixed>,features?:array<string,mixed>,savedGroups?:array<string,array<string,mixed>>,forcedVariations?:array<string,int>,qaMode?:bool,trackingCallback?:callable,cache?:\Psr\SimpleCache\CacheInterface,httpClient?:\Psr\Http\Client\ClientInterface,requestFactory?:\Psr\Http\Message\RequestFactoryInterface,decryptionKey?:string,forcedFeatures?:array<string, FeatureResult<mixed>>,plugins?:Plugin[]} $options
      */
     public function __construct(array $options = [])
     {
@@ -122,7 +125,8 @@ class Growthbook implements LoggerAwareInterface
             "savedGroups",
             "encryptedSavedGroups",
             "apiTimeout",
-            "apiConnectTimeout"
+            "apiConnectTimeout",
+            "plugins"
         ];
         $unknownOptions = array_diff(array_keys($options), $knownOptions);
         if (count($unknownOptions)) {
@@ -164,6 +168,22 @@ class Growthbook implements LoggerAwareInterface
         }
         if (array_key_exists("savedGroups", $options)) {
             $this->setSavedGroups(($options["savedGroups"]));
+        }
+        if (array_key_exists("plugins", $options)) {
+            foreach ($options["plugins"] as $plugin) {
+                $this->addPlugin($plugin);
+            }
+        }
+    }
+
+    public function __destruct()
+    {
+        foreach ($this->plugins as $plugin) {
+            try {
+                $plugin->close();
+            } catch (\Throwable $e) {
+                // never propagate plugin errors
+            }
         }
     }
 
@@ -461,6 +481,12 @@ class Growthbook implements LoggerAwareInterface
         return $self;
     }
 
+    public function addPlugin(Plugin $plugin): static
+    {
+        $this->plugins[] = $plugin;
+        return $this;
+    }
+
     /**
      * @param array<string>|null $stickyBucketIdentifierAttributes
      */
@@ -616,7 +642,7 @@ class Growthbook implements LoggerAwareInterface
 
         foreach ($parentConditions as $parentCondition) {
             $conditionId = $parentCondition['id'] ?? null;
-            $parentRes = $this->getFeature($conditionId, $stack);
+            $parentRes = $this->evaluateFeature($conditionId, $stack);
 
             if ($parentRes->source === "cyclicPrerequisite") {
                 return "cyclic";
@@ -652,6 +678,26 @@ class Growthbook implements LoggerAwareInterface
      * @return FeatureResult<T>|FeatureResult<null>
      */
     public function getFeature(string $key, array $stack = []): FeatureResult
+    {
+        $result = $this->evaluateFeature($key, $stack);
+        if (empty($stack)) {
+            foreach ($this->plugins as $plugin) {
+                try {
+                    $plugin->onFeatureEvaluated($key, $result);
+                } catch (\Throwable $e) {
+                    // never propagate plugin errors
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param string        $key
+     * @param array<string> $stack
+     * @return FeatureResult<mixed>
+     */
+    private function evaluateFeature(string $key, array $stack): FeatureResult
     {
         if (!array_key_exists($key, $this->features)) {
             $this->log(LogLevel::DEBUG, "Unknown feature - $key");
@@ -1015,6 +1061,13 @@ class Growthbook implements LoggerAwareInterface
                 }
             }
         }
+        foreach ($this->plugins as $plugin) {
+            try {
+                $plugin->onExperimentViewed($exp, $result);
+            } catch (\Throwable $e) {
+                // never propagate plugin errors
+            }
+        }
 
         // 15. Return the result
         $this->log(LogLevel::DEBUG, "Assigned user a variation", [
@@ -1355,6 +1408,7 @@ class Growthbook implements LoggerAwareInterface
                             $this->log(LogLevel::INFO, "Load saved groups from cache", ["url" => $url, "numGroups" => count($decoded['savedGroups'])]);
                             $this->setSavedGroups($decoded['savedGroups']);
                         }
+                        $this->initializePlugins();
                         return;
                     }
                     $cachedData = $decoded;
@@ -1432,6 +1486,19 @@ class Growthbook implements LoggerAwareInterface
                 if (array_key_exists("savedGroups", $cachedData) && is_array($cachedData['savedGroups'])) {
                     $this->setSavedGroups($cachedData['savedGroups']);
                 }
+            }
+        }
+
+        $this->initializePlugins();
+    }
+
+    private function initializePlugins(): void
+    {
+        foreach ($this->plugins as $plugin) {
+            try {
+                $plugin->initialize($this->clientKey);
+            } catch (\Throwable $e) {
+                // never propagate plugin errors
             }
         }
     }

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -133,9 +133,9 @@ class Growthbook implements LoggerAwareInterface
             trigger_error('Unknown Config options: ' . implode(", ", $unknownOptions), E_USER_NOTICE);
         }
 
-        $this->pluginRegistry = new PluginRegistry();
         $this->enabled = $options["enabled"] ?? true;
         $this->logger = $options["logger"] ?? null;
+        $this->pluginRegistry = new PluginRegistry([], $this->logger);
         $this->url = $options["url"] ?? $_SERVER['REQUEST_URI'] ?? "";
         $this->forcedVariations = $options["forcedVariations"] ?? [];
         $this->qaMode = $options["qaMode"] ?? false;
@@ -355,6 +355,7 @@ class Growthbook implements LoggerAwareInterface
     public function setLogger(?LoggerInterface $logger = null): void
     {
         $this->logger = $logger;
+        $this->pluginRegistry->setLogger($logger);
     }
 
     /**

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -86,8 +86,8 @@ class Growthbook implements LoggerAwareInterface
     /** @var int */
     private $apiConnectTimeout = self::DEFAULT_API_TIMEOUT;
 
-    /** @var Plugin[] */
-    private $plugins = [];
+    /** @var PluginRegistry */
+    private $pluginRegistry;
 
     /**
      * @param array<string, mixed> $options
@@ -133,6 +133,7 @@ class Growthbook implements LoggerAwareInterface
             trigger_error('Unknown Config options: ' . implode(", ", $unknownOptions), E_USER_NOTICE);
         }
 
+        $this->pluginRegistry = new PluginRegistry();
         $this->enabled = $options["enabled"] ?? true;
         $this->logger = $options["logger"] ?? null;
         $this->url = $options["url"] ?? $_SERVER['REQUEST_URI'] ?? "";
@@ -178,13 +179,7 @@ class Growthbook implements LoggerAwareInterface
 
     public function __destruct()
     {
-        foreach ($this->plugins as $plugin) {
-            try {
-                $plugin->close();
-            } catch (\Throwable $e) {
-                // never propagate plugin errors
-            }
-        }
+        $this->pluginRegistry->close();
     }
 
     /**
@@ -483,7 +478,7 @@ class Growthbook implements LoggerAwareInterface
 
     public function addPlugin(Plugin $plugin): static
     {
-        $this->plugins[] = $plugin;
+        $this->pluginRegistry->add($plugin);
         return $this;
     }
 
@@ -681,13 +676,7 @@ class Growthbook implements LoggerAwareInterface
     {
         $result = $this->evaluateFeature($key, $stack);
         if (empty($stack)) {
-            foreach ($this->plugins as $plugin) {
-                try {
-                    $plugin->onFeatureEvaluated($key, $result);
-                } catch (\Throwable $e) {
-                    // never propagate plugin errors
-                }
-            }
+            $this->pluginRegistry->onFeatureEvaluated($key, $result);
         }
         return $result;
     }
@@ -1061,13 +1050,7 @@ class Growthbook implements LoggerAwareInterface
                 }
             }
         }
-        foreach ($this->plugins as $plugin) {
-            try {
-                $plugin->onExperimentViewed($exp, $result);
-            } catch (\Throwable $e) {
-                // never propagate plugin errors
-            }
-        }
+        $this->pluginRegistry->onExperimentViewed($exp, $result);
 
         // 15. Return the result
         $this->log(LogLevel::DEBUG, "Assigned user a variation", [
@@ -1494,13 +1477,7 @@ class Growthbook implements LoggerAwareInterface
 
     private function initializePlugins(): void
     {
-        foreach ($this->plugins as $plugin) {
-            try {
-                $plugin->initialize($this->clientKey);
-            } catch (\Throwable $e) {
-                // never propagate plugin errors
-            }
-        }
+        $this->pluginRegistry->initialize($this->clientKey);
     }
 
     /**

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -676,7 +676,7 @@ class Growthbook implements LoggerAwareInterface
     {
         $result = $this->evaluateFeature($key, $stack);
         if (empty($stack)) {
-            $this->pluginRegistry->onFeatureEvaluated($key, $result);
+            $this->pluginRegistry->onFeatureEvaluated($key, $result, $this->attributes);
         }
         return $result;
     }
@@ -1050,7 +1050,7 @@ class Growthbook implements LoggerAwareInterface
                 }
             }
         }
-        $this->pluginRegistry->onExperimentViewed($exp, $result);
+        $this->pluginRegistry->onExperimentViewed($exp, $result, $this->attributes);
 
         // 15. Return the result
         $this->log(LogLevel::DEBUG, "Assigned user a variation", [

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -1412,6 +1412,7 @@ class Growthbook implements LoggerAwareInterface
             } else {
                 $this->log(LogLevel::WARNING, "HTTP client or request factory not set, unable to load features from API");
             }
+            $this->initializePlugins();
             return;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,13 +9,15 @@ interface Plugin
     /**
      * @param InlineExperiment<mixed> $experiment
      * @param ExperimentResult<mixed> $result
+     * @param array<string,mixed>     $attributes Current user attributes at the time of evaluation
      */
-    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void;
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result, array $attributes): void;
 
     /**
      * @param FeatureResult<mixed> $result
+     * @param array<string,mixed>  $attributes Current user attributes at the time of evaluation
      */
-    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void;
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result, array $attributes): void;
 
     public function close(): void;
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Growthbook;
+
+interface Plugin
+{
+    public function initialize(string $clientKey): void;
+
+    /**
+     * @param InlineExperiment<mixed> $experiment
+     * @param ExperimentResult<mixed> $result
+     */
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void;
+
+    /**
+     * @param FeatureResult<mixed> $result
+     */
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void;
+
+    public function close(): void;
+}

--- a/src/PluginRegistry.php
+++ b/src/PluginRegistry.php
@@ -2,6 +2,9 @@
 
 namespace Growthbook;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
 /**
  * Holds all registered plugins and dispatches lifecycle and evaluation
  * events to each one. A failure in one plugin never affects the others.
@@ -11,10 +14,21 @@ final class PluginRegistry
     /** @var Plugin[] */
     private array $plugins;
 
-    /** @param Plugin[] $plugins */
-    public function __construct(array $plugins = [])
+    private ?LoggerInterface $logger;
+
+    /**
+     * @param Plugin[]             $plugins
+     * @param LoggerInterface|null $logger
+     */
+    public function __construct(array $plugins = [], ?LoggerInterface $logger = null)
     {
         $this->plugins = $plugins;
+        $this->logger  = $logger;
+    }
+
+    public function setLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     public function add(Plugin $plugin): void
@@ -64,7 +78,12 @@ final class PluginRegistry
         try {
             $block();
         } catch (\Throwable $e) {
-            // never propagate plugin errors
+            if ($this->logger) {
+                $this->logger->log(LogLevel::ERROR, "Plugin error in " . get_class($plugin), [
+                    "error" => $e->getMessage(),
+                    "plugin" => get_class($plugin),
+                ]);
+            }
         }
     }
 }

--- a/src/PluginRegistry.php
+++ b/src/PluginRegistry.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Growthbook;
+
+/**
+ * Holds all registered plugins and dispatches lifecycle and evaluation
+ * events to each one. A failure in one plugin never affects the others.
+ */
+final class PluginRegistry
+{
+    /** @var Plugin[] */
+    private array $plugins;
+
+    /** @param Plugin[] $plugins */
+    public function __construct(array $plugins = [])
+    {
+        $this->plugins = $plugins;
+    }
+
+    public function add(Plugin $plugin): void
+    {
+        $this->plugins[] = $plugin;
+    }
+
+    public function initialize(string $clientKey): void
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->safeCall($plugin, fn() => $plugin->initialize($clientKey));
+        }
+    }
+
+    /**
+     * @param InlineExperiment<mixed> $experiment
+     * @param ExperimentResult<mixed> $result
+     */
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->safeCall($plugin, fn() => $plugin->onExperimentViewed($experiment, $result));
+        }
+    }
+
+    /**
+     * @param FeatureResult<mixed> $result
+     */
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->safeCall($plugin, fn() => $plugin->onFeatureEvaluated($featureKey, $result));
+        }
+    }
+
+    public function close(): void
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->safeCall($plugin, fn() => $plugin->close());
+        }
+    }
+
+    private function safeCall(Plugin $plugin, \Closure $block): void
+    {
+        try {
+            $block();
+        } catch (\Throwable $e) {
+            // never propagate plugin errors
+        }
+    }
+}

--- a/src/PluginRegistry.php
+++ b/src/PluginRegistry.php
@@ -32,21 +32,23 @@ final class PluginRegistry
     /**
      * @param InlineExperiment<mixed> $experiment
      * @param ExperimentResult<mixed> $result
+     * @param array<string,mixed>     $attributes
      */
-    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result, array $attributes): void
     {
         foreach ($this->plugins as $plugin) {
-            $this->safeCall($plugin, fn() => $plugin->onExperimentViewed($experiment, $result));
+            $this->safeCall($plugin, fn() => $plugin->onExperimentViewed($experiment, $result, $attributes));
         }
     }
 
     /**
      * @param FeatureResult<mixed> $result
+     * @param array<string,mixed>  $attributes
      */
-    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result, array $attributes): void
     {
         foreach ($this->plugins as $plugin) {
-            $this->safeCall($plugin, fn() => $plugin->onFeatureEvaluated($featureKey, $result));
+            $this->safeCall($plugin, fn() => $plugin->onFeatureEvaluated($featureKey, $result, $attributes));
         }
     }
 

--- a/tests/GrowthbookPluginTest.php
+++ b/tests/GrowthbookPluginTest.php
@@ -34,8 +34,9 @@ final class MockPlugin implements Plugin
     /**
      * @param InlineExperiment<mixed> $experiment
      * @param ExperimentResult<mixed> $result
+     * @param array<string,mixed>     $attributes
      */
-    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result, array $attributes): void
     {
         $this->experimentCallCount++;
         $this->experimentEvents[] = ['experiment' => $experiment, 'result' => $result];
@@ -43,8 +44,9 @@ final class MockPlugin implements Plugin
 
     /**
      * @param FeatureResult<mixed> $result
+     * @param array<string,mixed>  $attributes
      */
-    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result, array $attributes): void
     {
         $this->featureCallCount++;
         $this->featureEvents[] = ['key' => $featureKey, 'result' => $result];
@@ -223,10 +225,10 @@ final class GrowthbookPluginIntegrationTest extends TestCase
     {
         $badPlugin = new class implements Plugin {
             public function initialize(string $clientKey): void { throw new \RuntimeException("boom"); }
-            /** @param InlineExperiment<mixed> $e @param ExperimentResult<mixed> $r */
-            public function onExperimentViewed(InlineExperiment $e, ExperimentResult $r): void { throw new \RuntimeException("boom"); }
-            /** @param FeatureResult<mixed> $r */
-            public function onFeatureEvaluated(string $k, FeatureResult $r): void { throw new \RuntimeException("boom"); }
+            /** @param InlineExperiment<mixed> $e @param ExperimentResult<mixed> $r @param array<string,mixed> $a */
+            public function onExperimentViewed(InlineExperiment $e, ExperimentResult $r, array $a): void { throw new \RuntimeException("boom"); }
+            /** @param FeatureResult<mixed> $r @param array<string,mixed> $a */
+            public function onFeatureEvaluated(string $k, FeatureResult $r, array $a): void { throw new \RuntimeException("boom"); }
             public function close(): void { throw new \RuntimeException("boom"); }
         };
 
@@ -288,7 +290,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
         $plugin->initialize('');
         $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
         $plugin->close();
 
         $this->assertCount(0, $calls);
@@ -307,7 +309,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
         $exp = $this->makeExperiment();
         for ($i = 0; $i < 3; $i++) {
-            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
         }
 
         $this->assertCount(1, $calls);
@@ -324,7 +326,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
         $exp = $this->makeExperiment();
         for ($i = 0; $i < 4; $i++) {
-            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
         }
 
         $this->assertCount(0, $calls);
@@ -341,7 +343,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
 
         $this->assertCount(0, $calls, "no request before close()");
         $plugin->close();
@@ -367,7 +369,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
         $plugin->close();
         $plugin->close();
 
@@ -384,7 +386,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $plugin->initialize('my-client-key');
 
         $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
 
         $this->assertStringContainsString('client_key=my-client-key', $urls[0]);
         $this->assertStringContainsString('/track', $urls[0]);
@@ -400,16 +402,36 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment('my-experiment');
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), ['id' => 'user-1']);
 
         // Body must be a plain array, not wrapped in {client_key, events}
         $this->assertIsArray($bodies[0]);
         $this->assertArrayNotHasKey('client_key', $bodies[0]);
         $this->assertArrayNotHasKey('events', $bodies[0]);
+
         $event = $bodies[0][0];
-        $this->assertSame('experiment_viewed', $event['event']);
-        $this->assertSame('my-experiment', $event['experimentKey']);
-        $this->assertSame(1, $event['variationId']);
+        $this->assertSame('Experiment Viewed', $event['event_name']);
+        $this->assertSame('my-experiment', $event['properties']['experimentId']);
+        $this->assertSame(1, $event['properties']['variationId']);
+    }
+
+    public function testExperimentViewedAttributesMerged(): void
+    {
+        $bodies = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $url, string $body) use (&$bodies) {
+            $bodies[] = json_decode($body, true);
+        });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), ['id' => 'user-1', 'country' => 'UA']);
+
+        $attrs = $bodies[0][0]['attributes'];
+        $this->assertSame('user-1', $attrs['id']);
+        $this->assertSame('UA', $attrs['country']);
+        $this->assertSame('php', $attrs['sdk_language']);
+        $this->assertArrayHasKey('sdk_version', $attrs);
     }
 
     public function testFeatureEvaluatedEventFormat(): void
@@ -421,12 +443,13 @@ final class GrowthBookTrackingPluginTest extends TestCase
         });
         $plugin->initialize('sdk-test');
 
-        $plugin->onFeatureEvaluated('my-feature', $this->makeFeatureResult());
+        $plugin->onFeatureEvaluated('my-feature', $this->makeFeatureResult(), []);
 
         $event = $bodies[0][0];
-        $this->assertSame('feature_evaluated', $event['event']);
-        $this->assertSame('my-feature', $event['featureKey']);
-        $this->assertSame('defaultValue', $event['source']);
+        $this->assertSame('Feature Evaluated', $event['event_name']);
+        $this->assertSame('my-feature', $event['properties']['feature']);
+        $this->assertSame('defaultValue', $event['properties']['source']);
+        $this->assertSame('php', $event['attributes']['sdk_language']);
     }
 
     public function testMixedEventTypesInOneBatch(): void
@@ -439,12 +462,12 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
-        $plugin->onFeatureEvaluated('flag', $this->makeFeatureResult());
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp), []);
+        $plugin->onFeatureEvaluated('flag', $this->makeFeatureResult(), []);
 
         $this->assertCount(1, $bodies);
         $this->assertCount(2, $bodies[0]);
-        $this->assertSame('experiment_viewed', $bodies[0][0]['event']);
-        $this->assertSame('feature_evaluated', $bodies[0][1]['event']);
+        $this->assertSame('Experiment Viewed', $bodies[0][0]['event_name']);
+        $this->assertSame('Feature Evaluated', $bodies[0][1]['event_name']);
     }
 }

--- a/tests/GrowthbookPluginTest.php
+++ b/tests/GrowthbookPluginTest.php
@@ -282,25 +282,27 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
     public function testNoOpWithEmptyClientKey(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin(1);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) { $calls[] = $body; });
 
         $plugin->initialize('');
         $exp = $this->makeExperiment();
         $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
         $plugin->close();
 
-        $this->assertCount(0, $sent);
+        $this->assertCount(0, $calls);
     }
 
     // ---- Batch size flush ----
 
     public function testFlushWhenBatchSizeReached(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin(3);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) {
+            $calls[] = ['url' => $url, 'events' => json_decode($body, true)];
+        });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
@@ -308,16 +310,16 @@ final class GrowthBookTrackingPluginTest extends TestCase
             $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
         }
 
-        $this->assertCount(1, $sent);
-        $this->assertSame('sdk-test', $sent[0]['client_key']);
-        $this->assertCount(3, $sent[0]['events']);
+        $this->assertCount(1, $calls);
+        $this->assertStringContainsString('client_key=sdk-test', $calls[0]['url']);
+        $this->assertCount(3, $calls[0]['events']);
     }
 
     public function testNoFlushBeforeBatchSizeReached(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin(5);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) { $calls[] = $body; });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
@@ -325,7 +327,7 @@ final class GrowthBookTrackingPluginTest extends TestCase
             $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
         }
 
-        $this->assertCount(0, $sent);
+        $this->assertCount(0, $calls);
         $plugin->close();
     }
 
@@ -333,58 +335,78 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
     public function testCloseFlushesSynchronously(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin(100);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) { $calls[] = $body; });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
         $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
 
-        $this->assertCount(0, $sent, "no request before close()");
+        $this->assertCount(0, $calls, "no request before close()");
         $plugin->close();
-        $this->assertCount(1, $sent, "close() must flush synchronously");
+        $this->assertCount(1, $calls, "close() must flush synchronously");
     }
 
     public function testCloseWithNoEventsDoesNotSendRequest(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin();
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) { $calls[] = $body; });
         $plugin->initialize('sdk-test');
         $plugin->close();
 
-        $this->assertCount(0, $sent);
+        $this->assertCount(0, $calls);
     }
 
     public function testCloseIsIdempotent(): void
     {
-        $sent = [];
+        $calls = [];
         $plugin = $this->makePlugin(100);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$calls) { $calls[] = $body; });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
         $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
         $plugin->close();
-        $plugin->close(); // second call must not send again
+        $plugin->close();
 
-        $this->assertCount(1, $sent);
+        $this->assertCount(1, $calls);
     }
 
-    // ---- Payload format ----
+    // ---- Request format ----
 
-    public function testExperimentViewedEventFormat(): void
+    public function testClientKeyInQueryString(): void
     {
-        $sent = [];
+        $urls = [];
         $plugin = $this->makePlugin(1);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$urls) { $urls[] = $url; });
+        $plugin->initialize('my-client-key');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+
+        $this->assertStringContainsString('client_key=my-client-key', $urls[0]);
+        $this->assertStringContainsString('/track', $urls[0]);
+    }
+
+    public function testBodyIsPlainEventArray(): void
+    {
+        $bodies = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $url, string $body) use (&$bodies) {
+            $bodies[] = json_decode($body, true);
+        });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment('my-experiment');
         $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
 
-        $event = $sent[0]['events'][0];
+        // Body must be a plain array, not wrapped in {client_key, events}
+        $this->assertIsArray($bodies[0]);
+        $this->assertArrayNotHasKey('client_key', $bodies[0]);
+        $this->assertArrayNotHasKey('events', $bodies[0]);
+        $event = $bodies[0][0];
         $this->assertSame('experiment_viewed', $event['event']);
         $this->assertSame('my-experiment', $event['experimentKey']);
         $this->assertSame(1, $event['variationId']);
@@ -392,46 +414,37 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
     public function testFeatureEvaluatedEventFormat(): void
     {
-        $sent = [];
+        $bodies = [];
         $plugin = $this->makePlugin(1);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$bodies) {
+            $bodies[] = json_decode($body, true);
+        });
         $plugin->initialize('sdk-test');
 
         $plugin->onFeatureEvaluated('my-feature', $this->makeFeatureResult());
 
-        $event = $sent[0]['events'][0];
+        $event = $bodies[0][0];
         $this->assertSame('feature_evaluated', $event['event']);
         $this->assertSame('my-feature', $event['featureKey']);
         $this->assertSame('defaultValue', $event['source']);
     }
 
-    public function testPayloadContainsClientKey(): void
-    {
-        $sent = [];
-        $plugin = $this->makePlugin(1);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
-        $plugin->initialize('my-client-key');
-
-        $exp = $this->makeExperiment();
-        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
-
-        $this->assertSame('my-client-key', $sent[0]['client_key']);
-    }
-
     public function testMixedEventTypesInOneBatch(): void
     {
-        $sent = [];
+        $bodies = [];
         $plugin = $this->makePlugin(2);
-        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->setSendHandler(function (string $url, string $body) use (&$bodies) {
+            $bodies[] = json_decode($body, true);
+        });
         $plugin->initialize('sdk-test');
 
         $exp = $this->makeExperiment();
         $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
         $plugin->onFeatureEvaluated('flag', $this->makeFeatureResult());
 
-        $this->assertCount(1, $sent);
-        $this->assertCount(2, $sent[0]['events']);
-        $this->assertSame('experiment_viewed', $sent[0]['events'][0]['event']);
-        $this->assertSame('feature_evaluated', $sent[0]['events'][1]['event']);
+        $this->assertCount(1, $bodies);
+        $this->assertCount(2, $bodies[0]);
+        $this->assertSame('experiment_viewed', $bodies[0][0]['event']);
+        $this->assertSame('feature_evaluated', $bodies[0][1]['event']);
     }
 }

--- a/tests/GrowthbookPluginTest.php
+++ b/tests/GrowthbookPluginTest.php
@@ -11,10 +11,6 @@ use Growthbook\InlineExperiment;
 use Growthbook\Plugin;
 use PHPUnit\Framework\TestCase;
 
-// ---------------------------------------------------------------------------
-// MockPlugin — records all plugin calls for assertions
-// ---------------------------------------------------------------------------
-
 final class MockPlugin implements Plugin
 {
     public ?string $initializedWith = null;
@@ -59,10 +55,6 @@ final class MockPlugin implements Plugin
     }
 }
 
-// ---------------------------------------------------------------------------
-// Plugin integration tests
-// ---------------------------------------------------------------------------
-
 final class GrowthbookPluginIntegrationTest extends TestCase
 {
     private function makeGrowthbook(MockPlugin ...$plugins): Growthbook
@@ -73,8 +65,6 @@ final class GrowthbookPluginIntegrationTest extends TestCase
         }
         return $gb;
     }
-
-    // ---- Lifecycle ----
 
     public function testPluginReceivesInitialize(): void
     {
@@ -102,8 +92,6 @@ final class GrowthbookPluginIntegrationTest extends TestCase
         $this->assertTrue($plugin->closeCalled);
     }
 
-    // ---- Experiment events ----
-
     public function testPluginReceivesOnExperimentViewed(): void
     {
         $plugin = new MockPlugin();
@@ -127,8 +115,6 @@ final class GrowthbookPluginIntegrationTest extends TestCase
 
         $this->assertSame(0, $plugin->experimentCallCount);
     }
-
-    // ---- Feature events ----
 
     public function testPluginReceivesOnFeatureEvaluated(): void
     {
@@ -195,8 +181,6 @@ final class GrowthbookPluginIntegrationTest extends TestCase
         $this->assertSame(2, $plugin->featureCallCount);
     }
 
-    // ---- Multiple plugins ----
-
     public function testMultiplePluginsAllReceiveEvents(): void
     {
         $p1 = new MockPlugin();
@@ -246,10 +230,6 @@ final class GrowthbookPluginIntegrationTest extends TestCase
     }
 }
 
-// ---------------------------------------------------------------------------
-// GrowthBookTrackingPlugin unit tests
-// ---------------------------------------------------------------------------
-
 final class GrowthBookTrackingPluginTest extends TestCase
 {
     private function makePlugin(int $batchSize = GrowthBookTrackingPluginConfig::DEFAULT_BATCH_SIZE): GrowthBookTrackingPlugin
@@ -280,8 +260,6 @@ final class GrowthBookTrackingPluginTest extends TestCase
         return new FeatureResult(true, 'defaultValue');
     }
 
-    // ---- No-op without clientKey ----
-
     public function testNoOpWithEmptyClientKey(): void
     {
         $calls = [];
@@ -295,8 +273,6 @@ final class GrowthBookTrackingPluginTest extends TestCase
 
         $this->assertCount(0, $calls);
     }
-
-    // ---- Batch size flush ----
 
     public function testFlushWhenBatchSizeReached(): void
     {
@@ -332,8 +308,6 @@ final class GrowthBookTrackingPluginTest extends TestCase
         $this->assertCount(0, $calls);
         $plugin->close();
     }
-
-    // ---- close() synchronous flush ----
 
     public function testCloseFlushesSynchronously(): void
     {

--- a/tests/GrowthbookPluginTest.php
+++ b/tests/GrowthbookPluginTest.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Growthbook\ExperimentResult;
 use Growthbook\FeatureResult;
 use Growthbook\GrowthBookTrackingPlugin;
+use Growthbook\GrowthBookTrackingPluginConfig;
 use Growthbook\Growthbook;
 use Growthbook\InlineExperiment;
 use Growthbook\Plugin;
@@ -251,11 +252,10 @@ final class GrowthbookPluginIntegrationTest extends TestCase
 
 final class GrowthBookTrackingPluginTest extends TestCase
 {
-    private function makePlugin(int $batchSize = GrowthBookTrackingPlugin::DEFAULT_BATCH_SIZE): GrowthBookTrackingPlugin
+    private function makePlugin(int $batchSize = GrowthBookTrackingPluginConfig::DEFAULT_BATCH_SIZE): GrowthBookTrackingPlugin
     {
         return new GrowthBookTrackingPlugin(
-            GrowthBookTrackingPlugin::DEFAULT_INGESTOR_HOST,
-            $batchSize
+            new GrowthBookTrackingPluginConfig(batchSize: $batchSize)
         );
     }
 

--- a/tests/GrowthbookPluginTest.php
+++ b/tests/GrowthbookPluginTest.php
@@ -1,0 +1,437 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Growthbook\ExperimentResult;
+use Growthbook\FeatureResult;
+use Growthbook\GrowthBookTrackingPlugin;
+use Growthbook\Growthbook;
+use Growthbook\InlineExperiment;
+use Growthbook\Plugin;
+use PHPUnit\Framework\TestCase;
+
+// ---------------------------------------------------------------------------
+// MockPlugin — records all plugin calls for assertions
+// ---------------------------------------------------------------------------
+
+final class MockPlugin implements Plugin
+{
+    public ?string $initializedWith = null;
+    public int $experimentCallCount = 0;
+    public int $featureCallCount    = 0;
+    public bool $closeCalled        = false;
+
+    /** @var array<int, array{experiment: InlineExperiment<mixed>, result: ExperimentResult<mixed>}> */
+    public array $experimentEvents = [];
+    /** @var array<int, array{key: string, result: FeatureResult<mixed>}> */
+    public array $featureEvents = [];
+
+    public function initialize(string $clientKey): void
+    {
+        $this->initializedWith = $clientKey;
+    }
+
+    /**
+     * @param InlineExperiment<mixed> $experiment
+     * @param ExperimentResult<mixed> $result
+     */
+    public function onExperimentViewed(InlineExperiment $experiment, ExperimentResult $result): void
+    {
+        $this->experimentCallCount++;
+        $this->experimentEvents[] = ['experiment' => $experiment, 'result' => $result];
+    }
+
+    /**
+     * @param FeatureResult<mixed> $result
+     */
+    public function onFeatureEvaluated(string $featureKey, FeatureResult $result): void
+    {
+        $this->featureCallCount++;
+        $this->featureEvents[] = ['key' => $featureKey, 'result' => $result];
+    }
+
+    public function close(): void
+    {
+        $this->closeCalled = true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin integration tests
+// ---------------------------------------------------------------------------
+
+final class GrowthbookPluginIntegrationTest extends TestCase
+{
+    private function makeGrowthbook(MockPlugin ...$plugins): Growthbook
+    {
+        $gb = Growthbook::create()->withAttributes(['id' => 'user-1']);
+        foreach ($plugins as $plugin) {
+            $gb->addPlugin($plugin);
+        }
+        return $gb;
+    }
+
+    // ---- Lifecycle ----
+
+    public function testPluginReceivesInitialize(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin);
+        // initialize() is called by the SDK's initialize() method which requires
+        // a real HTTP call, so we call it manually here to mirror the contract.
+        $plugin->initialize('sdk-test-key');
+        $this->assertSame('sdk-test-key', $plugin->initializedWith);
+    }
+
+    public function testPluginCloseCalledOnDestruct(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin);
+        unset($gb);
+        $this->assertTrue($plugin->closeCalled);
+    }
+
+    public function testPluginAddedViaConstructorOption(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = new Growthbook(['plugins' => [$plugin], 'attributes' => ['id' => 'user-1']]);
+        unset($gb);
+        $this->assertTrue($plugin->closeCalled);
+    }
+
+    // ---- Experiment events ----
+
+    public function testPluginReceivesOnExperimentViewed(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin);
+
+        $exp = InlineExperiment::create('my-exp', ['A', 'B'])->withCoverage(1.0);
+        $gb->runInlineExperiment($exp);
+
+        $this->assertSame(1, $plugin->experimentCallCount);
+        $this->assertSame('my-exp', $plugin->experimentEvents[0]['experiment']->key);
+    }
+
+    public function testPluginNotCalledWhenUserNotInExperiment(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin);
+
+        // coverage = 0 → user never assigned → inExperiment = false
+        $exp = InlineExperiment::create('my-exp-zero', ['A', 'B'])->withCoverage(0.0);
+        $gb->runInlineExperiment($exp);
+
+        $this->assertSame(0, $plugin->experimentCallCount);
+    }
+
+    // ---- Feature events ----
+
+    public function testPluginReceivesOnFeatureEvaluated(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin)->withFeatures([
+            'flag-a' => ['defaultValue' => true],
+        ]);
+
+        $gb->getFeature('flag-a');
+
+        $this->assertSame(1, $plugin->featureCallCount);
+        $this->assertSame('flag-a', $plugin->featureEvents[0]['key']);
+    }
+
+    public function testPluginReceivesFeatureEvaluatedForUnknownFeature(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin)->withFeatures([]);
+
+        $gb->getFeature('nonexistent');
+
+        $this->assertSame(1, $plugin->featureCallCount);
+        $this->assertSame('nonexistent', $plugin->featureEvents[0]['key']);
+        $this->assertSame('unknownFeature', $plugin->featureEvents[0]['result']->source);
+    }
+
+    public function testPluginNotCalledForPrerequisiteFeatureEvaluation(): void
+    {
+        // Prerequisite features are evaluated internally (stack != []),
+        // so the plugin should only fire once for the top-level feature.
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin)->withFeatures([
+            'parent' => ['defaultValue' => true],
+            'child'  => [
+                'defaultValue' => false,
+                'rules'        => [
+                    [
+                        'parentConditions' => [
+                            ['id' => 'parent', 'condition' => ['value' => true]],
+                        ],
+                        'force' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $gb->getFeature('child');
+
+        // Only one plugin call for 'child', not for the internal 'parent' evaluation
+        $this->assertSame(1, $plugin->featureCallCount);
+        $this->assertSame('child', $plugin->featureEvents[0]['key']);
+    }
+
+    public function testIsOnAndIsOffTriggerPluginOnce(): void
+    {
+        $plugin = new MockPlugin();
+        $gb = $this->makeGrowthbook($plugin)->withFeatures([
+            'flag-b' => ['defaultValue' => true],
+        ]);
+
+        $gb->isOn('flag-b');
+        $gb->isOff('flag-b');
+
+        $this->assertSame(2, $plugin->featureCallCount);
+    }
+
+    // ---- Multiple plugins ----
+
+    public function testMultiplePluginsAllReceiveEvents(): void
+    {
+        $p1 = new MockPlugin();
+        $p2 = new MockPlugin();
+        $gb = $this->makeGrowthbook($p1, $p2)->withFeatures([
+            'flag-c' => ['defaultValue' => 42],
+        ]);
+
+        $gb->getFeature('flag-c');
+
+        $this->assertSame(1, $p1->featureCallCount);
+        $this->assertSame(1, $p2->featureCallCount);
+    }
+
+    public function testMultiplePluginsAllReceiveClose(): void
+    {
+        $p1 = new MockPlugin();
+        $p2 = new MockPlugin();
+        $gb = $this->makeGrowthbook($p1, $p2);
+        unset($gb);
+
+        $this->assertTrue($p1->closeCalled);
+        $this->assertTrue($p2->closeCalled);
+    }
+
+    public function testMisbehavingPluginDoesNotAffectOtherPlugins(): void
+    {
+        $badPlugin = new class implements Plugin {
+            public function initialize(string $clientKey): void { throw new \RuntimeException("boom"); }
+            /** @param InlineExperiment<mixed> $e @param ExperimentResult<mixed> $r */
+            public function onExperimentViewed(InlineExperiment $e, ExperimentResult $r): void { throw new \RuntimeException("boom"); }
+            /** @param FeatureResult<mixed> $r */
+            public function onFeatureEvaluated(string $k, FeatureResult $r): void { throw new \RuntimeException("boom"); }
+            public function close(): void { throw new \RuntimeException("boom"); }
+        };
+
+        $goodPlugin = new MockPlugin();
+        $gb = Growthbook::create()
+            ->withAttributes(['id' => 'user-1'])
+            ->withFeatures(['flag-d' => ['defaultValue' => true]]);
+        $gb->addPlugin($badPlugin);
+        $gb->addPlugin($goodPlugin);
+
+        $gb->getFeature('flag-d');
+
+        $this->assertSame(1, $goodPlugin->featureCallCount);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GrowthBookTrackingPlugin unit tests
+// ---------------------------------------------------------------------------
+
+final class GrowthBookTrackingPluginTest extends TestCase
+{
+    private function makePlugin(int $batchSize = GrowthBookTrackingPlugin::DEFAULT_BATCH_SIZE): GrowthBookTrackingPlugin
+    {
+        return new GrowthBookTrackingPlugin(
+            GrowthBookTrackingPlugin::DEFAULT_INGESTOR_HOST,
+            $batchSize
+        );
+    }
+
+    /** @return InlineExperiment<mixed> */
+    private function makeExperiment(string $key = 'test-exp'): InlineExperiment
+    {
+        return InlineExperiment::create($key, [0, 1]);
+    }
+
+    /**
+     * @param InlineExperiment<mixed> $exp
+     * @return ExperimentResult<mixed>
+     */
+    private function makeExperimentResult(InlineExperiment $exp): ExperimentResult
+    {
+        return new ExperimentResult($exp, 'id', 'user-1', 1, true, null);
+    }
+
+    /** @return FeatureResult<mixed> */
+    private function makeFeatureResult(): FeatureResult
+    {
+        return new FeatureResult(true, 'defaultValue');
+    }
+
+    // ---- No-op without clientKey ----
+
+    public function testNoOpWithEmptyClientKey(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+
+        $plugin->initialize('');
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->close();
+
+        $this->assertCount(0, $sent);
+    }
+
+    // ---- Batch size flush ----
+
+    public function testFlushWhenBatchSizeReached(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(3);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        for ($i = 0; $i < 3; $i++) {
+            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        }
+
+        $this->assertCount(1, $sent);
+        $this->assertSame('sdk-test', $sent[0]['client_key']);
+        $this->assertCount(3, $sent[0]['events']);
+    }
+
+    public function testNoFlushBeforeBatchSizeReached(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(5);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        for ($i = 0; $i < 4; $i++) {
+            $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        }
+
+        $this->assertCount(0, $sent);
+        $plugin->close();
+    }
+
+    // ---- close() synchronous flush ----
+
+    public function testCloseFlushesSynchronously(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(100);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+
+        $this->assertCount(0, $sent, "no request before close()");
+        $plugin->close();
+        $this->assertCount(1, $sent, "close() must flush synchronously");
+    }
+
+    public function testCloseWithNoEventsDoesNotSendRequest(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin();
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->initialize('sdk-test');
+        $plugin->close();
+
+        $this->assertCount(0, $sent);
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(100);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = $payload; });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->close();
+        $plugin->close(); // second call must not send again
+
+        $this->assertCount(1, $sent);
+    }
+
+    // ---- Payload format ----
+
+    public function testExperimentViewedEventFormat(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment('my-experiment');
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+
+        $event = $sent[0]['events'][0];
+        $this->assertSame('experiment_viewed', $event['event']);
+        $this->assertSame('my-experiment', $event['experimentKey']);
+        $this->assertSame(1, $event['variationId']);
+    }
+
+    public function testFeatureEvaluatedEventFormat(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->initialize('sdk-test');
+
+        $plugin->onFeatureEvaluated('my-feature', $this->makeFeatureResult());
+
+        $event = $sent[0]['events'][0];
+        $this->assertSame('feature_evaluated', $event['event']);
+        $this->assertSame('my-feature', $event['featureKey']);
+        $this->assertSame('defaultValue', $event['source']);
+    }
+
+    public function testPayloadContainsClientKey(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(1);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->initialize('my-client-key');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+
+        $this->assertSame('my-client-key', $sent[0]['client_key']);
+    }
+
+    public function testMixedEventTypesInOneBatch(): void
+    {
+        $sent = [];
+        $plugin = $this->makePlugin(2);
+        $plugin->setSendHandler(function (string $payload) use (&$sent) { $sent[] = json_decode($payload, true); });
+        $plugin->initialize('sdk-test');
+
+        $exp = $this->makeExperiment();
+        $plugin->onExperimentViewed($exp, $this->makeExperimentResult($exp));
+        $plugin->onFeatureEvaluated('flag', $this->makeFeatureResult());
+
+        $this->assertCount(1, $sent);
+        $this->assertCount(2, $sent[0]['events']);
+        $this->assertSame('experiment_viewed', $sent[0]['events'][0]['event']);
+        $this->assertSame('feature_evaluated', $sent[0]['events'][1]['event']);
+    }
+}


### PR DESCRIPTION
 ## Summary
  - Adds `Plugin` interface and `PluginRegistry` for dispatching lifecycle and evaluation events to registered plugins
  - Built-in `GrowthBookTrackingPlugin` batches events and POSTs them to the GrowthBook ingest endpoint (`POST /track?client_key=...`)
  - Plugins receive current user `attributes` on every callback
  - SDK version read automatically from Composer at runtime
  - PSR-3 logger support — plugin errors are logged instead of silently dropped
  
  ## Event format
  ```json
  {
    "event_name": "Experiment Viewed",
    "properties": { "experimentId": "my-exp", "variationId": 1 },
    "attributes": { "id": "user-1", "sdk_language": "php", "sdk_version": "1.3.0" }
  } 
  ```
  
  ## Usage
  ```php
  $gb = Growthbook::create()
      ->addPlugin(new GrowthBookTrackingPlugin());
      
  $gb->initialize('sdk-abc123');
  ```

  ## Test plan
  - 23 new tests in `GrowthbookPluginTest.php` — all pass
  - Existing 519 tests — no regressions
  - phpstan level 5 — no errors