### PR TITLE
feat: add customFields property to Experiment and FeatureRule

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -13,7 +13,7 @@ class Feature
     public $rules = [];
 
     /**
-     * @param array{defaultValue:T,rules:?array{condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>}[]} $feature
+     * @param array{defaultValue:T,rules:?array{condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>,customFields:?array<string,mixed>}[]} $feature
      */
     public function __construct(array $feature)
     {

--- a/src/FeatureRule.php
+++ b/src/FeatureRule.php
@@ -55,8 +55,11 @@ class FeatureRule
     /** @var null|array<string, mixed> */
     public $parentConditions;
 
+    /** @var null|array<string, mixed> */
+    public $customFields;
+
     /**
-     * @param array{id?:string,condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>} $rule
+     * @param array{id?:string,condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>,customFields:?array<string,mixed>} $rule
      */
     public function __construct(array $rule)
     {
@@ -126,6 +129,9 @@ class FeatureRule
         if (array_key_exists("parentConditions", $rule)) {
             $this->parentConditions = $rule["parentConditions"];
         }
+        if (array_key_exists("customFields", $rule)) {
+            $this->customFields = $rule["customFields"];
+        }
     }
 
     /**
@@ -190,6 +196,9 @@ class FeatureRule
         }
         if (isset($this->parentConditions)) {
             $exp->parentConditions = $this->parentConditions;
+        }
+        if (isset($this->customFields)) {
+            $exp->customFields = $this->customFields;
         }
 
         return $exp;

--- a/src/InlineExperiment.php
+++ b/src/InlineExperiment.php
@@ -55,6 +55,11 @@ class InlineExperiment
     public $parentConditions;
 
     /**
+     * @var array<string,mixed>|null
+     */
+    public $customFields;
+
+    /**
      * @param string $key
      * @param T[] $variations
      * @return InlineExperiment<T>
@@ -67,7 +72,7 @@ class InlineExperiment
     /**
      * @param string $key
      * @param T[] $variations
-     * @param array{weights?: float[], coverage?: float, force?: int|null, active?: bool, condition?: array<string, mixed>, namespace?: array{0: string, 1: float, 2: float}, hashAttribute?: string, fallbackAttribute?: string, filters?: array{seed: string, ranges: array{0: float, 1: float}[], hashVersion?: int, attribute?: string}[], seed?: string, hashVersion?: int, meta?: array{key?: string, name?: string, passthrough?: bool}[], ranges?: array{0: float, 1: float}[], name?: string, phase?: string, disableStickyBucketing?: bool, bucketVersion?: int, minBucketVersion?: int} $options
+     * @param array{weights?: float[], coverage?: float, force?: int|null, active?: bool, condition?: array<string, mixed>, namespace?: array{0: string, 1: float, 2: float}, hashAttribute?: string, fallbackAttribute?: string, filters?: array{seed: string, ranges: array{0: float, 1: float}[], hashVersion?: int, attribute?: string}[], seed?: string, hashVersion?: int, meta?: array{key?: string, name?: string, passthrough?: bool}[], ranges?: array{0: float, 1: float}[], name?: string, phase?: string, disableStickyBucketing?: bool, bucketVersion?: int, minBucketVersion?: int, customFields?: array<string, mixed>} $options
      */
     public function __construct(string $key, $variations, array $options = [])
     {
@@ -91,6 +96,7 @@ class InlineExperiment
         $this->bucketVersion = $options["bucketVersion"] ?? null;
         $this->minBucketVersion = $options["minBucketVersion"] ?? null;
         $this->parentConditions = $options["parentConditions"] ?? null;
+        $this->customFields = $options["customFields"] ?? null;
         $this->fallbackAttribute = null;
         if (!is_null($this->disableStickyBucketing)) {
             $this->fallbackAttribute = $options["fallbackAttribute"] ?? null;

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1256,4 +1256,46 @@ final class GrowthbookTest extends TestCase
             '$regexi - invalid pattern' => ['$regexi', 'Hello', '[', false],
         ];
     }
+
+    public function testInlineExperimentCustomFields(): void
+    {
+        $customFields = ['badge' => 'new', 'priority' => 1];
+
+        $exp = new InlineExperiment('my-test', [0, 1], ['customFields' => $customFields]);
+
+        $this->assertSame($customFields, $exp->customFields);
+    }
+
+    public function testInlineExperimentCustomFieldsDefaultNull(): void
+    {
+        $exp = new InlineExperiment('my-test', [0, 1]);
+
+        $this->assertNull($exp->customFields);
+    }
+
+    public function testFeatureRuleCustomFieldsPassedToExperiment(): void
+    {
+        $customFields = ['color' => 'blue', 'weight' => 2.5];
+
+        /** @phpstan-ignore-next-line */
+        $rule = new \Growthbook\FeatureRule(['variations' => [false, true], 'customFields' => $customFields]);
+
+        $exp = $rule->toExperiment('test-feature');
+
+        $this->assertNotNull($exp);
+        assert($exp !== null);
+        $this->assertSame($customFields, $exp->customFields);
+    }
+
+    public function testFeatureRuleWithoutCustomFieldsProducesNullOnExperiment(): void
+    {
+        /** @phpstan-ignore-next-line */
+        $rule = new \Growthbook\FeatureRule(['variations' => [false, true]]);
+
+        $exp = $rule->toExperiment('test-feature');
+
+        $this->assertNotNull($exp);
+        assert($exp !== null);
+        $this->assertNull($exp->customFields);
+    }
 }


### PR DESCRIPTION
## Summary
- Added `customFields` property to `InlineExperiment` as `array<string,mixed>|null`
- Added `customFields` parsing in `FeatureRule` and propagation to `InlineExperiment` via `toExperiment()`
- Updated `Feature` PHPDoc to include `customFields` in rules shape
- Added unit tests covering all scenarios

Mirrors implementation in C# and Swift SDKs.