### PR TITLE
fix: use stale cache as fallback when API is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ $growthbook = Growthbook\Growthbook::create()
   ->withCache($cache, 120); // Cache for 120s instead
 ```
 
+#### Cache Resilience
+
+If the GrowthBook API is unavailable and an expired cache exists, the SDK will automatically use the stale cached data as a fallback instead of failing. This means a brief API outage will not affect your users — features continue to work from the last known state.
+
+The cached data is stored with a hard TTL of 10× the configured TTL, so stale data remains available as a fallback for that duration.
+
 To load features, we require a PSR-17 (HttpClient) and PSR-18 (RequestFactoryInterface) compatible library like Guzzle to be installed.
 
 We will auto-discover most HTTP libraries without any configuration required, but if you prefer to specify it explicitly, you can use the `withHttpClient` method. Note - you'll need to specify both an `HttpClient` and a `RequestFactoryInterface` implementation.

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -1333,34 +1333,48 @@ class Growthbook implements LoggerAwareInterface
         if (!$this->clientKey) {
             throw new Exception("Must specify a clientKey before initializing.");
         }
-        if (!$this->httpClient) {
-            throw new Exception("Must set an HTTP Client before initializing.");
-        }
-        if (!$this->requestFactory) {
-            throw new Exception("Must set an HTTP Request Factory before initializing");
-        }
 
         $url = rtrim(empty($this->apiHost) ? self::DEFAULT_API_HOST : $this->apiHost, "/") . "/api/features/" . $this->clientKey;
         // Update when the cache format changes to prevent issues when updating the library version
         $cacheKey = md5($url . 'v2');
 
         // First try fetching from cache
+        $cachedData = null;
         if ($this->cache) {
             $cachedResponse = $this->cache->get($cacheKey);
             if ($cachedResponse) {
-                $cachedData = json_decode($cachedResponse, true);
-                if (is_array($cachedData)) {
-                    if (array_key_exists("features", $cachedData) && is_array($cachedData['features'])) {
-                        $this->log(LogLevel::INFO, "Load features from cache", ["url" => $url, "numFeatures" => count($cachedData['features'])]);
-                        $this->setFeatures($cachedData['features']);
+                $decoded = json_decode($cachedResponse, true);
+                if (is_array($decoded)) {
+                    $isFresh = isset($decoded['expiresAt']) && $decoded['expiresAt'] > time();
+                    if ($isFresh) {
+                        if (array_key_exists("features", $decoded) && is_array($decoded['features'])) {
+                            $this->log(LogLevel::INFO, "Load features from cache", ["url" => $url, "numFeatures" => count($decoded['features'])]);
+                            $this->setFeatures($decoded['features']);
+                        }
+                        if (array_key_exists("savedGroups", $decoded) && is_array($decoded['savedGroups'])) {
+                            $this->log(LogLevel::INFO, "Load saved groups from cache", ["url" => $url, "numGroups" => count($decoded['savedGroups'])]);
+                            $this->setSavedGroups($decoded['savedGroups']);
+                        }
+                        return;
                     }
-                    if (array_key_exists("savedGroups", $cachedData) && is_array($cachedData['savedGroups'])) {
-                        $this->log(LogLevel::INFO, "Load saved groups from cache", ["url" => $url, "numGroups" => count($cachedData['savedGroups'])]);
-                        $this->setSavedGroups($cachedData['savedGroups']);
-                    }
-                    return;
+                    $cachedData = $decoded;
                 }
             }
+        }
+
+        if (!$this->httpClient || !$this->requestFactory) {
+            if ($cachedData !== null) {
+                $this->log(LogLevel::WARNING, "HTTP client not set, using stale cache as fallback", ["url" => $url]);
+                if (array_key_exists("features", $cachedData) && is_array($cachedData['features'])) {
+                    $this->setFeatures($cachedData['features']);
+                }
+                if (array_key_exists("savedGroups", $cachedData) && is_array($cachedData['savedGroups'])) {
+                    $this->setSavedGroups($cachedData['savedGroups']);
+                }
+            } else {
+                $this->log(LogLevel::WARNING, "HTTP client or request factory not set, unable to load features from API");
+            }
+            return;
         }
 
         try {
@@ -1393,9 +1407,10 @@ class Growthbook implements LoggerAwareInterface
             if ($this->cache) {
                 $cacheData = [
                     'features' => $features,
-                    'savedGroups' => $savedGroups
+                    'savedGroups' => $savedGroups,
+                    'expiresAt' => time() + $this->cacheTTL
                 ];
-                $this->cache->set($cacheKey, json_encode($cacheData), $this->cacheTTL);
+                $this->cache->set($cacheKey, json_encode($cacheData), $this->cacheTTL * 10);
                 $this->log(LogLevel::INFO, "Cache features and saved groups", [
                     "url" => $url,
                     "numFeatures" => count($features),
@@ -1409,6 +1424,15 @@ class Growthbook implements LoggerAwareInterface
                 "error" => $e->getMessage(),
                 "errorClass" => get_class($e)
             ]);
+            if ($cachedData !== null) {
+                $this->log(LogLevel::WARNING, "Using stale cache as fallback", ["url" => $url]);
+                if (array_key_exists("features", $cachedData) && is_array($cachedData['features'])) {
+                    $this->setFeatures($cachedData['features']);
+                }
+                if (array_key_exists("savedGroups", $cachedData) && is_array($cachedData['savedGroups'])) {
+                    $this->setSavedGroups($cachedData['savedGroups']);
+                }
+            }
         }
     }
 

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1097,7 +1097,7 @@ final class GrowthbookTest extends TestCase
         $timeout = $ref->getProperty('apiTimeout');
         $timeout->setAccessible(true);
 
-        $this->assertEquals(2, $timeout->getValue($gb1)); 
+        $this->assertEquals(2, $timeout->getValue($gb1));
         $this->assertEquals(10, $timeout->getValue($gb2));
     }
 
@@ -1120,7 +1120,7 @@ final class GrowthbookTest extends TestCase
 
     public function testInitializeHandlesTimeoutGracefully(): void
     {
-        $exception = new class ('Connection timed out') extends \RuntimeException implements \Psr\Http\Client\ClientExceptionInterface {};
+        $exception = new class('Connection timed out') extends \RuntimeException implements \Psr\Http\Client\ClientExceptionInterface {};
 
         $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
 
@@ -1140,6 +1140,50 @@ final class GrowthbookTest extends TestCase
         $gb->initialize('sdk-abc123');
 
         $this->assertEmpty($gb->getFeatures());
+    }
+
+    public function testInitializeUsesStaleCacheWhenNoHttpClient(): void
+    {
+        $staleData = json_encode([
+            'features' => ['my-feature' => ['defaultValue' => true]],
+            'savedGroups' => [],
+            'expiresAt' => time() - 100,
+        ]);
+
+        $cache = $this->createMock(\Psr\SimpleCache\CacheInterface::class);
+        $cache->method('get')->willReturn($staleData);
+
+        $gb = Growthbook::create()->withCache($cache);
+        $gb->initialize('sdk-abc123');
+
+        $this->assertTrue($gb->isOn('my-feature'));
+    }
+
+    public function testInitializeUsesStaleCacheWhenApiFails(): void
+    {
+        $staleData = json_encode([
+            'features' => ['my-feature' => ['defaultValue' => true]],
+            'savedGroups' => [],
+            'expiresAt' => time() - 100
+        ]);
+
+        $cache = $this->createMock(\Psr\SimpleCache\CacheInterface::class);
+        $cache->method('get')->willReturn($staleData);
+
+        $exception = new class('timeout') extends \RuntimeException implements \Psr\Http\Client\ClientExceptionInterface {};
+        $mockClient = $this->createMock(\Psr\Http\Client\ClientInterface::class);
+        $mockClient->method('sendRequest')->willThrowException($exception);
+        $mockFactory = $this->createMock(\Psr\Http\Message\RequestFactoryInterface::class);
+        $mockFactory->method('createRequest')->willReturn($this->createMock(\Psr\Http\Message\RequestInterface::class));
+
+        $gb = new Growthbook([
+            'httpClient' => $mockClient,
+            'requestFactory' => $mockFactory,
+        ]);
+        $gb->setCache($cache);
+        $gb->initialize('sdk-abc123');
+
+        $this->assertTrue($gb->isOn('my-feature'));
     }
 
     public function testTrackingCallbackExceptionWithLogger(): void


### PR DESCRIPTION
## Summary
- When the API is unavailable (connection error, timeout), the SDK now falls back to stale cached data instead of failing silently with empty features
- When HTTP client is not configured but stale cache exists, features are loaded from stale cache
- Cache now stores an `expiresAt` timestamp inside the payload with a hard TTL of `cacheTTL * 10`, replacing the previous two-key approach

Fixes #21