### PR TITLE
feat: add remote evaluation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,48 @@ $savedGroups = json_decode($savedGroupsJSON, true);
 $growthbook = $growthbook->withSavedGroups($savedGroups);
 ```
 
+## Remote Evaluation
+
+With remote evaluation, feature flags are evaluated on a self-hosted GrowthBook proxy/edge instead of locally in the SDK. Instead of downloading the full feature definitions, the SDK sends the current evaluation context (attributes, forced variations, forced features and URL) to the proxy via a `POST` request, and the proxy returns only the already-evaluated features. This keeps feature definitions and targeting logic off the client.
+
+Enable it by setting `remoteEval` to `true`:
+
+```php
+$growthbook = new Growthbook\Growthbook([
+  'remoteEval' => true,
+  'attributes' => ['id' => 'user-123'],
+]);
+
+// Sends a POST to https://gb-proxy.example.com/api/eval/sdk-abc123
+$growthbook->initialize('sdk-abc123', 'https://gb-proxy.example.com');
+```
+
+### Requirements and constraints
+
+Remote evaluation requires a **self-hosted** GrowthBook proxy/edge and is **not** supported on GrowthBook Cloud. The following combinations throw an exception:
+
+- A GrowthBook Cloud host (`*.growthbook.io`) — you must point `$apiHost` at your own proxy/edge.
+- A `decryptionKey` — encryption is handled by the proxy, not the SDK.
+- A `stickyBucketService` — sticky bucketing is handled server-side.
+
+### Cache key attributes
+
+When a cache is configured, remote eval responses are cached per evaluation context. By default every attribute is part of the cache key. Use `cacheKeyAttributes` to restrict the key to a subset of attributes, so that changes to irrelevant attributes don't cause unnecessary requests:
+
+```php
+$growthbook = new Growthbook\Growthbook([
+  'remoteEval' => true,
+  'cacheKeyAttributes' => ['id'], // only `id` affects the cache key
+  'cache' => $cache,
+]);
+```
+
+> Note: forced features are intentionally excluded from the cache key (they are applied client-side and the proxy does not filter on them).
+
+### Re-evaluation when the context changes
+
+Because the proxy evaluates features for a specific context, the SDK automatically re-fetches when that context changes after `initialize`. Calling `setAttributes`, `setForcedVariations` or `setUrl` (or their `withX` equivalents) triggers a new request. Thanks to the cache key above, repeated contexts are served from cache without a network call.
+
 ## The Growthbook Class
 
 The `Growthbook` class has a number of properties. These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:

--- a/src/FeatureRule.php
+++ b/src/FeatureRule.php
@@ -58,8 +58,11 @@ class FeatureRule
     /** @var null|array<string, mixed> */
     public $customFields;
 
+    /** @var null|array<int, array{experiment?:array<string,mixed>,result?:array<string,mixed>}> */
+    public $tracks;
+
     /**
-     * @param array{id?:string,condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>,customFields:?array<string,mixed>} $rule
+     * @param array{id?:string,condition:?array<string,mixed>,coverage:?float,force:?T,variations:?T[],key:?string,weights:?float[],namespace:?array{0:string,1:float,2:float},hashAttribute:?string,fallbackAttribute:?string,filters?:array{seed:string,ranges:array{0:float,1:float}[],hashVersion?:int,attribute?:string}[],seed?:string,hashVersion?:int,range?:array{0:float,1:float},meta?:array{key?:string,name?:string,passthrough?:bool}[],ranges?:array{0:float,1:float}[],name?:string,phase?:string,disableStickyBucketing:?bool,bucketVersion:?int,minBucketVersion:?int,parentConditions:?array<string,mixed>,customFields:?array<string,mixed>,tracks?:array<int, array{experiment?:array<string,mixed>,result?:array<string,mixed>}>} $rule
      */
     public function __construct(array $rule)
     {
@@ -131,6 +134,9 @@ class FeatureRule
         }
         if (array_key_exists("customFields", $rule)) {
             $this->customFields = $rule["customFields"];
+        }
+        if (array_key_exists("tracks", $rule)) {
+            $this->tracks = $rule["tracks"];
         }
     }
 

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -92,6 +92,12 @@ class Growthbook implements LoggerAwareInterface
     /** @var PluginRegistry */
     private $pluginRegistry;
 
+    /** @var bool */
+    private $remoteEval = false;
+
+    /** @var array<string>|null */
+    private $cacheKeyAttributes = null;
+
     /**
      * @param array<string, mixed> $options
      * @return static
@@ -104,7 +110,7 @@ class Growthbook implements LoggerAwareInterface
     }
 
     /**
-     * @param array{enabled?:bool,logger?:\Psr\Log\LoggerInterface,url?:string,attributes?:array<string,mixed>,features?:array<string,mixed>,savedGroups?:array<string,array<string,mixed>>,forcedVariations?:array<string,int>,qaMode?:bool,trackingCallback?:callable,cache?:\Psr\SimpleCache\CacheInterface,httpClient?:\Psr\Http\Client\ClientInterface,requestFactory?:\Psr\Http\Message\RequestFactoryInterface,decryptionKey?:string,forcedFeatures?:array<string, FeatureResult<mixed>>,plugins?:Plugin[]} $options
+     * @param array{enabled?:bool,logger?:\Psr\Log\LoggerInterface,url?:string,attributes?:array<string,mixed>,features?:array<string,mixed>,savedGroups?:array<string,array<string,mixed>>,forcedVariations?:array<string,int>,qaMode?:bool,trackingCallback?:callable,cache?:\Psr\SimpleCache\CacheInterface,httpClient?:\Psr\Http\Client\ClientInterface,requestFactory?:\Psr\Http\Message\RequestFactoryInterface,decryptionKey?:string,forcedFeatures?:array<string, FeatureResult<mixed>>,plugins?:Plugin[],remoteEval?:bool,cacheKeyAttributes?:array<string>} $options
      */
     public function __construct(array $options = [])
     {
@@ -130,7 +136,9 @@ class Growthbook implements LoggerAwareInterface
             "apiTimeout",
             "apiConnectTimeout",
             "plugins",
-            "etagCacheSize"
+            "etagCacheSize",
+            "remoteEval",
+            "cacheKeyAttributes"
         ];
         $unknownOptions = array_diff(array_keys($options), $knownOptions);
         if (count($unknownOptions)) {
@@ -180,6 +188,12 @@ class Growthbook implements LoggerAwareInterface
                 $this->addPlugin($plugin);
             }
         }
+        if (array_key_exists("cacheKeyAttributes", $options)) {
+            $this->setCacheKeyAttributes($options["cacheKeyAttributes"]);
+        }
+        if (array_key_exists("remoteEval", $options)) {
+            $this->setRemoteEval($options["remoteEval"]);
+        }
     }
 
     public function __destruct()
@@ -195,6 +209,7 @@ class Growthbook implements LoggerAwareInterface
     {
         $this->attributes = $attributes;
         $this->refreshStickyBuckets();
+        $this->refreshForRemoteEval();
 
         return $this;
     }
@@ -295,6 +310,7 @@ class Growthbook implements LoggerAwareInterface
     public function setForcedVariations(array $forcedVariations): static
     {
         $this->forcedVariations = $forcedVariations;
+        $this->refreshForRemoteEval();
         return $this;
     }
 
@@ -339,6 +355,7 @@ class Growthbook implements LoggerAwareInterface
     public function setUrl(string $url): static
     {
         $this->url = $url;
+        $this->refreshForRemoteEval();
         return $this;
     }
 
@@ -486,6 +503,72 @@ class Growthbook implements LoggerAwareInterface
     {
         $this->pluginRegistry->add($plugin);
         return $this;
+    }
+
+    /**
+     * Enable or disable remote evaluation mode. When enabled, feature evaluation
+     * is delegated to a self-hosted GrowthBook proxy/edge via POST /api/eval/{clientKey}.
+     *
+     * @param bool $remoteEval
+     * @return static
+     */
+    public function setRemoteEval(bool $remoteEval): static
+    {
+        $this->remoteEval = $remoteEval;
+        return $this;
+    }
+
+    /**
+     * @param bool $remoteEval
+     * @return static
+     */
+    public function withRemoteEval(bool $remoteEval): static
+    {
+        $self = clone $this;
+        $self->setRemoteEval($remoteEval);
+
+        return $self;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRemoteEval(): bool
+    {
+        return $this->remoteEval;
+    }
+
+    /**
+     * Restrict which attributes participate in the remote eval cache key.
+     * Only meaningful when remote evaluation is enabled. Pass null to use all attributes.
+     *
+     * @param array<string>|null $cacheKeyAttributes
+     * @return static
+     */
+    public function setCacheKeyAttributes(?array $cacheKeyAttributes): static
+    {
+        $this->cacheKeyAttributes = $cacheKeyAttributes;
+        return $this;
+    }
+
+    /**
+     * @param array<string>|null $cacheKeyAttributes
+     * @return static
+     */
+    public function withCacheKeyAttributes(?array $cacheKeyAttributes): static
+    {
+        $self = clone $this;
+        $self->setCacheKeyAttributes($cacheKeyAttributes);
+
+        return $self;
+    }
+
+    /**
+     * @return array<string>|null
+     */
+    public function getCacheKeyAttributes(): ?array
+    {
+        return $this->cacheKeyAttributes;
     }
 
     /**
@@ -787,6 +870,10 @@ class Growthbook implements LoggerAwareInterface
                         "feature" => $key,
                         "value" => $rule->force
                     ]);
+                    // Fire deferred experiment tracking events that were evaluated server-side (remote eval)
+                    if ($rule->tracks) {
+                        $this->fireRuleTracks($rule->tracks);
+                    }
                     $result = new FeatureResult($rule->force, "force", null, null, $rule->id);
                     $this->fireFeatureUsageCallback($key, $result);
                     return $result;
@@ -1108,6 +1195,63 @@ class Growthbook implements LoggerAwareInterface
         }
     }
 
+    /**
+     * Fire tracking callbacks for experiments that were evaluated server-side and
+     * attached to a force rule via its "tracks" array (remote evaluation).
+     *
+     * @param array<int, array{experiment?:array<string,mixed>,result?:array<string,mixed>}> $tracks
+     * @return void
+     */
+    private function fireRuleTracks(array $tracks): void
+    {
+        foreach ($tracks as $track) {
+            $expData = $track['experiment'] ?? null;
+            $resData = $track['result'] ?? null;
+
+            if (!is_array($expData) || !is_array($resData) || !isset($expData['key']) || !isset($expData['variations'])) {
+                $this->log(LogLevel::WARNING, "Skipping malformed track entry");
+                continue;
+            }
+
+            /** @var InlineExperiment<mixed> $exp */
+            $exp = new InlineExperiment($expData['key'], $expData['variations'], $expData);
+
+            $result = new ExperimentResult(
+                $exp,
+                (string)($resData['hashAttribute'] ?? 'id'),
+                (string)($resData['hashValue'] ?? ''),
+                (int)($resData['variationId'] ?? -1),
+                (bool)($resData['hashUsed'] ?? false),
+                $resData['featureId'] ?? null,
+                isset($resData['bucket']) ? (float)$resData['bucket'] : null,
+                (bool)($resData['stickyBucketUsed'] ?? false)
+            );
+
+            // Deduplicate identical tracking calls (same logic as runExperiment)
+            $dedupeKey = $result->hashAttribute . $result->hashValue . $exp->key . $result->variationId;
+            if (isset($this->tracks[$dedupeKey])) {
+                continue;
+            }
+            $this->tracks[$dedupeKey] = new ViewedExperiment($exp, $result);
+
+            if ($this->trackingCallback) {
+                try {
+                    call_user_func($this->trackingCallback, $exp, $result);
+                } catch (\Throwable $e) {
+                    if ($this->logger) {
+                        $this->log(LogLevel::ERROR, "Error calling the trackingCallback function", [
+                            "experiment" => $exp->key,
+                            "error" => $e
+                        ]);
+                    } else {
+                        throw $e;
+                    }
+                }
+            }
+            $this->pluginRegistry->onExperimentViewed($exp, $result, $this->attributes);
+        }
+    }
+
     public static function hash(string $seed, string $value, int $version): ?float
     {
         // New hashing algorithm
@@ -1376,6 +1520,13 @@ class Growthbook implements LoggerAwareInterface
             throw new Exception("Must specify a clientKey before initializing.");
         }
 
+        // Remote evaluation delegates feature evaluation to a self-hosted proxy/edge
+        if ($this->remoteEval) {
+            $this->fetchRemoteEval();
+            $this->initializePlugins();
+            return;
+        }
+
         $url = rtrim(empty($this->apiHost) ? self::DEFAULT_API_HOST : $this->apiHost, "/") . "/api/features/" . $this->clientKey;
         // Update when the cache format changes to prevent issues when updating the library version
         $cacheKey = md5($url . 'v2');
@@ -1519,6 +1670,252 @@ class Growthbook implements LoggerAwareInterface
     private function initializePlugins(): void
     {
         $this->pluginRegistry->initialize($this->clientKey);
+    }
+
+    /**
+     * Re-fetch remotely evaluated features when the evaluation context changes.
+     * No-op unless remote eval is enabled and the instance has already been initialized.
+     * Backed by the response cache, so repeated contexts do not trigger network calls.
+     *
+     * @return void
+     */
+    private function refreshForRemoteEval(): void
+    {
+        if (!$this->remoteEval || !$this->clientKey) {
+            return;
+        }
+        $this->fetchRemoteEval();
+    }
+
+    /**
+     * Validate that the current configuration is compatible with remote evaluation.
+     *
+     * @return void
+     * @throws Exception
+     */
+    private function validateRemoteEval(): void
+    {
+        if ($this->decryptionKey) {
+            throw new Exception("Encryption is not available for remoteEval");
+        }
+        if ($this->stickyBucketService) {
+            throw new Exception("stickyBucketService is not compatible with remoteEval; the proxy handles sticky bucketing server-side");
+        }
+
+        $host = empty($this->apiHost) ? self::DEFAULT_API_HOST : $this->apiHost;
+        $hostname = parse_url($host, PHP_URL_HOST);
+        if (is_string($hostname) && preg_match('/growthbook\.io$/i', $hostname)) {
+            throw new Exception("Cannot use remoteEval on GrowthBook Cloud; use a self-hosted proxy/edge");
+        }
+    }
+
+    /**
+     * Build the POST body sent to the remote eval endpoint.
+     *
+     * @return array{attributes:array<string,mixed>,forcedFeatures:array<array{0:string,1:mixed}>,forcedVariations:array<string,int>,url:string}
+     */
+    private function buildRemoteEvalPayload(): array
+    {
+        $forcedFeatures = [];
+        foreach ($this->forcedFeatures as $key => $value) {
+            $forcedFeatures[] = [$key, $value->value];
+        }
+
+        return [
+            "attributes" => $this->attributes,
+            "forcedFeatures" => $forcedFeatures,
+            "forcedVariations" => $this->forcedVariations,
+            "url" => $this->url,
+        ];
+    }
+
+    /**
+     * Compute the cache key for a remote eval response. The key includes the
+     * attributes (optionally narrowed by cacheKeyAttributes), forcedVariations and url.
+     * forcedFeatures are deliberately excluded - they are applied client-side and the
+     * proxy does not filter on them.
+     *
+     * @param string                                                                                                       $url
+     * @param array{attributes:array<string,mixed>,forcedFeatures:array<array{0:string,1:mixed}>,forcedVariations:array<string,int>,url:string} $payload
+     * @return string
+     */
+    private function getRemoteEvalCacheKey(string $url, array $payload): string
+    {
+        $attributes = $payload["attributes"];
+        if ($this->cacheKeyAttributes !== null) {
+            $ca = [];
+            foreach ($this->cacheKeyAttributes as $attr) {
+                $ca[$attr] = $attributes[$attr] ?? null;
+            }
+        } else {
+            $ca = $attributes;
+        }
+
+        $keyData = [
+            "ca" => $ca,
+            "fv" => $payload["forcedVariations"],
+            "url" => $payload["url"],
+        ];
+
+        // Sort keys recursively so the serialized key is canonical regardless of
+        // attribute/forcedVariation insertion order. Matches Python (sort_keys=True)
+        // and Java (TreeMap) - important because PHP caches are often shared across
+        // processes (e.g. Redis), where insertion order is not guaranteed.
+        self::ksortRecursive($keyData);
+
+        return md5($url . "||" . json_encode($keyData) . "v2");
+    }
+
+    /**
+     * Recursively sort an array by key (associative arrays only; lists are left as-is).
+     *
+     * @param array<mixed> $array
+     * @return void
+     */
+    private static function ksortRecursive(array &$array): void
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                self::ksortRecursive($value);
+            }
+        }
+        unset($value);
+
+        // Only reorder associative arrays; preserve the order of sequential lists
+        if ($array !== [] && array_keys($array) !== range(0, count($array) - 1)) {
+            ksort($array);
+        }
+    }
+
+    /**
+     * Apply a remote eval response (features + savedGroups) to the instance.
+     *
+     * @param array<string,mixed> $data
+     * @param string              $source Human readable source for logging
+     * @return void
+     */
+    private function applyRemoteEvalData(array $data, string $source): void
+    {
+        if (array_key_exists("features", $data) && is_array($data["features"])) {
+            $this->log(LogLevel::INFO, "Load remote eval features from $source", ["numFeatures" => count($data["features"])]);
+            $this->setFeatures($data["features"]);
+        }
+        if (array_key_exists("savedGroups", $data) && is_array($data["savedGroups"])) {
+            $this->setSavedGroups($data["savedGroups"]);
+        }
+    }
+
+    /**
+     * Fetch remotely evaluated features from a self-hosted proxy/edge via POST.
+     *
+     * @return void
+     * @throws ClientExceptionInterface
+     * @throws Exception
+     */
+    private function fetchRemoteEval(): void
+    {
+        $this->validateRemoteEval();
+
+        $url = rtrim(empty($this->apiHost) ? self::DEFAULT_API_HOST : $this->apiHost, "/") . "/api/eval/" . $this->clientKey;
+        $payload = $this->buildRemoteEvalPayload();
+        $cacheKey = $this->getRemoteEvalCacheKey($url, $payload);
+
+        // First try fetching from cache
+        $cachedData = null;
+        if ($this->cache) {
+            $cachedResponse = $this->cache->get($cacheKey);
+            if ($cachedResponse) {
+                $decoded = json_decode($cachedResponse, true);
+                if (is_array($decoded)) {
+                    $isFresh = isset($decoded['expiresAt']) && $decoded['expiresAt'] > time();
+                    if ($isFresh) {
+                        $this->applyRemoteEvalData($decoded, "cache");
+                        return;
+                    }
+                    $cachedData = $decoded;
+                }
+            }
+        }
+
+        if (!$this->httpClient || !$this->requestFactory) {
+            if ($cachedData !== null) {
+                $this->log(LogLevel::WARNING, "HTTP client not set, using stale cache as fallback", ["url" => $url]);
+                $this->applyRemoteEvalData($cachedData, "stale cache");
+            } else {
+                $this->log(LogLevel::WARNING, "HTTP client or request factory not set, unable to load remote eval features");
+            }
+            return;
+        }
+
+        try {
+            // attributes and forcedVariations must serialize as JSON objects ({}),
+            // not arrays ([]), even when empty - the eval endpoint rejects arrays.
+            // forcedFeatures is a list of [key, value] pairs and stays an array.
+            $wirePayload = [
+                "attributes" => (object) $payload["attributes"],
+                "forcedFeatures" => $payload["forcedFeatures"],
+                "forcedVariations" => (object) $payload["forcedVariations"],
+                "url" => $payload["url"],
+            ];
+            $body = json_encode($wirePayload) ?: "{}";
+            $req = $this->requestFactory->createRequest('POST', $url);
+            $req = $req->withHeader('User-Agent', 'growthbook-php/' . $this->sdkVersion());
+            $req = $req->withHeader('Content-Type', 'application/json');
+            \assert($req instanceof \Psr\Http\Message\RequestInterface);
+
+            $stream = $req->getBody();
+            $stream->write($body);
+            if ($stream->isSeekable()) {
+                $stream->rewind();
+            }
+
+            $res = $this->httpClient->sendRequest($req);
+            $statusCode = $res->getStatusCode();
+
+            if ($statusCode >= 400) {
+                $this->log(LogLevel::WARNING, "Remote eval request failed", ["url" => $url, "statusCode" => $statusCode]);
+                if ($cachedData !== null) {
+                    $this->applyRemoteEvalData($cachedData, "stale cache");
+                }
+                return;
+            }
+
+            $responseBody = $res->getBody()->getContents();
+            $parsed = json_decode($responseBody, true);
+            if (!is_array($parsed) || !array_key_exists("features", $parsed)) {
+                $this->log(LogLevel::WARNING, "Could not load remote eval features", ["url" => $url, "responseBody" => $responseBody]);
+                if ($cachedData !== null) {
+                    $this->applyRemoteEvalData($cachedData, "stale cache");
+                }
+                return;
+            }
+
+            $features = is_array($parsed["features"]) ? $parsed["features"] : [];
+            $savedGroups = (array_key_exists("savedGroups", $parsed) && is_array($parsed["savedGroups"])) ? $parsed["savedGroups"] : [];
+
+            $this->log(LogLevel::INFO, "Load remote eval features from URL", ["url" => $url, "numFeatures" => count($features), "numGroups" => count($savedGroups)]);
+            $this->setFeatures($features);
+            $this->setSavedGroups($savedGroups);
+
+            if ($this->cache) {
+                $cacheData = [
+                    'features' => $features,
+                    'savedGroups' => $savedGroups,
+                    'expiresAt' => time() + $this->cacheTTL,
+                ];
+                $this->cache->set($cacheKey, json_encode($cacheData), $this->cacheTTL * 10);
+            }
+        } catch (\Throwable $e) {
+            $this->log(LogLevel::ERROR, "Failed to fetch remote eval features from API", [
+                "url" => $url,
+                "error" => $e->getMessage(),
+                "errorClass" => get_class($e),
+            ]);
+            if ($cachedData !== null) {
+                $this->log(LogLevel::WARNING, "Using stale cache as fallback", ["url" => $url]);
+                $this->applyRemoteEvalData($cachedData, "stale cache");
+            }
+        }
     }
 
     private static function sdkVersion(): string

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1634,4 +1634,316 @@ final class GrowthbookTest extends TestCase
             $this->assertCount(2, $range, 'FeatureRule ranges must round-trip as [start, end] arrays');
         }
     }
+
+    // ---------------------------------------------------------------------
+    // Remote evaluation
+    // ---------------------------------------------------------------------
+
+    /**
+     * Build mock HTTP client + request factory that capture the outgoing request
+     * (method, url, body) and return a fixed response.
+     *
+     * @param string                   $responseBody
+     * @param int                      $statusCode
+     * @param array<string,mixed>|null $captured     Filled by reference with method/url/body
+     * @return array{0:\Psr\Http\Client\ClientInterface,1:\Psr\Http\Message\RequestFactoryInterface}
+     */
+    private function makeRemoteEvalHttp(string $responseBody, int $statusCode, &$captured): array
+    {
+        $captured = ['body' => '', 'sendCount' => 0];
+
+        $bodyStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $bodyStream->method('write')->willReturnCallback(function ($s) use (&$captured) {
+            $captured['body'] .= $s;
+            return strlen($s);
+        });
+        $bodyStream->method('isSeekable')->willReturn(true);
+
+        $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $mockRequest->method('withHeader')->willReturnSelf();
+        $mockRequest->method('getBody')->willReturn($bodyStream);
+
+        $mockFactory = $this->createMock(\Psr\Http\Message\RequestFactoryInterface::class);
+        $mockFactory->method('createRequest')->willReturnCallback(function ($method, $url) use (&$captured, $mockRequest) {
+            $captured['method'] = $method;
+            $captured['url'] = $url;
+            return $mockRequest;
+        });
+
+        $respStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $respStream->method('getContents')->willReturn($responseBody);
+
+        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn($statusCode);
+        $mockResponse->method('getBody')->willReturn($respStream);
+
+        $mockClient = $this->createMock(\Psr\Http\Client\ClientInterface::class);
+        $mockClient->method('sendRequest')->willReturnCallback(function () use (&$captured, $mockResponse) {
+            $captured['sendCount']++;
+            return $mockResponse;
+        });
+
+        return [$mockClient, $mockFactory];
+    }
+
+    public function testRemoteEvalSendsPostToEvalEndpoint(): void
+    {
+        $response = (string) json_encode([
+            'features' => ['my-feature' => ['defaultValue' => true]],
+            'savedGroups' => [],
+        ]);
+
+        [$client, $factory] = $this->makeRemoteEvalHttp($response, 200, $captured);
+
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $client,
+            'requestFactory' => $factory,
+            'attributes' => ['id' => 'u1', 'country' => 'US'],
+            'forcedVariations' => ['exp-1' => 2],
+            'url' => '/checkout',
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+
+        // Endpoint + method
+        $this->assertSame('POST', $captured['method']);
+        $this->assertSame('https://proxy.example.com/api/eval/sdk-test', $captured['url']);
+
+        // Request body shape
+        $body = json_decode($captured['body'], true);
+        $this->assertSame(['id' => 'u1', 'country' => 'US'], $body['attributes']);
+        $this->assertSame(['exp-1' => 2], $body['forcedVariations']);
+        $this->assertSame('/checkout', $body['url']);
+        $this->assertSame([], $body['forcedFeatures']);
+
+        // Response applied
+        $this->assertTrue($gb->isOn('my-feature'));
+    }
+
+    public function testRemoteEvalSerializesForcedFeaturesAsPairs(): void
+    {
+        $response = (string) json_encode(['features' => [], 'savedGroups' => []]);
+        [$client, $factory] = $this->makeRemoteEvalHttp($response, 200, $captured);
+
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $client,
+            'requestFactory' => $factory,
+            'forcedFeatures' => ['banner' => new FeatureResult('v2', 'force')],
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+
+        $body = json_decode($captured['body'], true);
+        $this->assertSame([['banner', 'v2']], $body['forcedFeatures']);
+    }
+
+    public function testRemoteEvalSerializesEmptyMapsAsObjects(): void
+    {
+        $response = (string) json_encode(['features' => [], 'savedGroups' => []]);
+        [$client, $factory] = $this->makeRemoteEvalHttp($response, 200, $captured);
+
+        // No attributes and no forcedVariations: both must still serialize as {} not []
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $client,
+            'requestFactory' => $factory,
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+
+        $this->assertStringContainsString('"attributes":{}', $captured['body']);
+        $this->assertStringContainsString('"forcedVariations":{}', $captured['body']);
+        // forcedFeatures is a list and stays an array
+        $this->assertStringContainsString('"forcedFeatures":[]', $captured['body']);
+    }
+
+    public function testRemoteEvalRejectsDecryptionKey(): void
+    {
+        $gb = new Growthbook(['remoteEval' => true]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Encryption is not available for remoteEval');
+        $gb->initialize('sdk-test', 'https://proxy.example.com', 'some-decryption-key');
+    }
+
+    public function testRemoteEvalRejectsStickyBucketService(): void
+    {
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'stickyBucketService' => new InMemoryStickyBucketService(),
+        ]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('stickyBucketService is not compatible with remoteEval');
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+    }
+
+    public function testRemoteEvalRejectsCloudHost(): void
+    {
+        $gb = new Growthbook(['remoteEval' => true]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot use remoteEval on GrowthBook Cloud');
+        $gb->initialize('sdk-test', 'https://cdn.growthbook.io');
+    }
+
+    public function testRemoteEvalCacheKeyExcludesForcedFeatures(): void
+    {
+        $gb = new Growthbook(['remoteEval' => true]);
+
+        $ref = new \ReflectionMethod($gb, 'getRemoteEvalCacheKey');
+        $ref->setAccessible(true);
+
+        $url = 'https://proxy.example.com/api/eval/sdk-test';
+        $base = ['attributes' => ['id' => 'u1'], 'forcedVariations' => [], 'url' => ''];
+
+        $keyA = $ref->invoke($gb, $url, $base + ['forcedFeatures' => [['a', 1]]]);
+        $keyB = $ref->invoke($gb, $url, $base + ['forcedFeatures' => [['b', 2]]]);
+
+        $this->assertSame($keyA, $keyB, 'forcedFeatures must not affect the cache key');
+    }
+
+    public function testRemoteEvalCacheKeyUsesCacheKeyAttributes(): void
+    {
+        $gb = new Growthbook(['remoteEval' => true, 'cacheKeyAttributes' => ['id']]);
+
+        $ref = new \ReflectionMethod($gb, 'getRemoteEvalCacheKey');
+        $ref->setAccessible(true);
+
+        $url = 'https://proxy.example.com/api/eval/sdk-test';
+
+        // Only 'id' is part of the key, so changing 'country' must not change the key
+        $keyA = $ref->invoke($gb, $url, ['attributes' => ['id' => 'u1', 'country' => 'US'], 'forcedFeatures' => [], 'forcedVariations' => [], 'url' => '']);
+        $keyB = $ref->invoke($gb, $url, ['attributes' => ['id' => 'u1', 'country' => 'UA'], 'forcedFeatures' => [], 'forcedVariations' => [], 'url' => '']);
+        $this->assertSame($keyA, $keyB);
+
+        // Changing 'id' must change the key
+        $keyC = $ref->invoke($gb, $url, ['attributes' => ['id' => 'u2', 'country' => 'US'], 'forcedFeatures' => [], 'forcedVariations' => [], 'url' => '']);
+        $this->assertNotSame($keyA, $keyC);
+    }
+
+    public function testRemoteEvalCacheKeyIsOrderIndependent(): void
+    {
+        $gb = new Growthbook(['remoteEval' => true]);
+
+        $ref = new \ReflectionMethod($gb, 'getRemoteEvalCacheKey');
+        $ref->setAccessible(true);
+
+        $url = 'https://proxy.example.com/api/eval/sdk-test';
+
+        $keyA = $ref->invoke($gb, $url, [
+            'attributes' => ['id' => 'u1', 'country' => 'US'],
+            'forcedFeatures' => [],
+            'forcedVariations' => ['a' => 1, 'b' => 0],
+            'url' => '',
+        ]);
+        $keyB = $ref->invoke($gb, $url, [
+            'attributes' => ['country' => 'US', 'id' => 'u1'],
+            'forcedFeatures' => [],
+            'forcedVariations' => ['b' => 0, 'a' => 1],
+            'url' => '',
+        ]);
+
+        $this->assertSame($keyA, $keyB, 'Cache key must be independent of attribute/forcedVariation order');
+    }
+
+    public function testRemoteEvalAutoRefetchOnSetAttributes(): void
+    {
+        $response = (string) json_encode(['features' => [], 'savedGroups' => []]);
+        [$client, $factory] = $this->makeRemoteEvalHttp($response, 200, $captured);
+
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $client,
+            'requestFactory' => $factory,
+            'attributes' => ['id' => 'u1'],
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+        $this->assertSame(1, $captured['sendCount']);
+
+        // New context -> new POST
+        $gb->setAttributes(['id' => 'u2']);
+        $this->assertSame(2, $captured['sendCount']);
+    }
+
+    public function testRemoteEvalFiresRuleTracks(): void
+    {
+        $response = (string) json_encode([
+            'features' => [
+                'ab-feature' => [
+                    'defaultValue' => false,
+                    'rules' => [[
+                        'force' => true,
+                        'tracks' => [[
+                            'experiment' => ['key' => 'exp-A', 'variations' => [0, 1]],
+                            'result' => [
+                                'variationId' => 1,
+                                'inExperiment' => true,
+                                'value' => 1,
+                                'hashUsed' => true,
+                                'hashAttribute' => 'id',
+                                'hashValue' => 'u1',
+                                'featureId' => 'ab-feature',
+                                'key' => '1',
+                            ],
+                        ]],
+                    ]],
+                ],
+            ],
+            'savedGroups' => [],
+        ]);
+
+        [$client, $factory] = $this->makeRemoteEvalHttp($response, 200, $captured);
+
+        $tracked = [];
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $client,
+            'requestFactory' => $factory,
+            'attributes' => ['id' => 'u1'],
+            'trackingCallback' => function ($exp, $result) use (&$tracked) {
+                $tracked[] = [$exp, $result];
+            },
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+
+        // Evaluating the feature triggers the force rule, which fires the tracks
+        $this->assertTrue($gb->isOn('ab-feature'));
+
+        $this->assertCount(1, $tracked);
+        [$exp, $result] = $tracked[0];
+        $this->assertSame('exp-A', $exp->key);
+        $this->assertSame(1, $result->variationId);
+        $this->assertSame(1, $result->value);
+        $this->assertTrue($result->inExperiment);
+    }
+
+    public function testRemoteEvalFallsBackToStaleCacheOnError(): void
+    {
+        $staleData = json_encode([
+            'features' => ['my-feature' => ['defaultValue' => true]],
+            'savedGroups' => [],
+            'expiresAt' => time() - 100,
+        ]);
+        $cache = $this->createMock(\Psr\SimpleCache\CacheInterface::class);
+        $cache->method('get')->willReturn($staleData);
+
+        $exception = new class('timeout') extends \RuntimeException implements \Psr\Http\Client\ClientExceptionInterface {};
+        $mockClient = $this->createMock(\Psr\Http\Client\ClientInterface::class);
+        $mockClient->method('sendRequest')->willThrowException($exception);
+        $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $mockRequest->method('withHeader')->willReturnSelf();
+        $mockRequest->method('getBody')->willReturn($this->createMock(\Psr\Http\Message\StreamInterface::class));
+        $mockFactory = $this->createMock(\Psr\Http\Message\RequestFactoryInterface::class);
+        $mockFactory->method('createRequest')->willReturn($mockRequest);
+
+        $gb = new Growthbook([
+            'remoteEval' => true,
+            'httpClient' => $mockClient,
+            'requestFactory' => $mockFactory,
+            'cache' => $cache,
+        ]);
+        $gb->initialize('sdk-test', 'https://proxy.example.com');
+
+        $this->assertTrue($gb->isOn('my-feature'));
+    }
 }


### PR DESCRIPTION
## Summary
Adds **remote evaluation** support to the PHP SDK. When enabled, feature evaluation is delegated to a self-hosted GrowthBook proxy/edge via `POST /api/eval/{clientKey}`: the SDK sends the current evaluation context and applies the already-evaluated features it receives back, instead of downloading full feature definitions and evaluating locally.

## What's included
- **New options** `remoteEval` (bool) and `cacheKeyAttributes` (string[]), with fluent (`withRemoteEval`, `withCacheKeyAttributes`) and setter/getter accessors (`setRemoteEval`, `isRemoteEval`, …).
- `initialize()` branches into a `POST /api/eval/{clientKey}` flow when remote eval is enabled, reusing the existing PSR-18 client. Request body: `{ attributes, forcedFeatures, forcedVariations, url }`.
- **Validation** of incompatible configurations (throws):
  - GrowthBook Cloud host (`*.growthbook.io`) — a self-hosted proxy/edge is required;
  - `decryptionKey` — encryption is handled by the proxy;
  - `stickyBucketService` — sticky bucketing is handled server-side.
- **Response caching** keyed by the evaluation context (`attributes` narrowed by `cacheKeyAttributes`, `forcedVariations`, `url`). The key is canonical  so it is stable across processes when a shared cache (e.g. Redis) is used. `forcedFeatures` is deliberately excluded from the key. Stale-cache fallback on network/HTTP errors.
- `Auto re-fetch` when the context changes after `initialize` (`setAttributes` / `setForcedVariations` / `setUrl`), guarded so it is a no-op until initialized and free for the common "set-then-initialize" flow. Backed by the cache, so repeated contexts don't hit the network.
- **Deferred experiment tracking**: fires the tracking callback for server-evaluated experiments attached to a force rule via its `tracks` array (`FeatureRule::$tracks`).
- `Correct JSON shape`: `attributes` and `forcedVariations` are serialized as objects (`{}`) even when empty (the eval endpoint rejects `[]`); `forcedFeatures` stays a list of `[key, value]` pairs.

### Usage

```php
$gb = new Growthbook\Growthbook([
  'remoteEval' => true,
  'attributes' => ['id' => 'user-123'],
]);
$gb->initialize('sdk-abc123', 'https://gb-proxy.example.com');
```