### PR TITLE
feat: add Psr16StickyBucketService and fix fallbackAttribute when sticky bucketing is disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,22 @@ By default GrowthBook does not persist assigned experiment variations for a user
 
 Sticky Bucketing is a solution to these issues. You can provide a Sticky Bucket Service to the GrowthBook instance to persist previously seen variations and ensure that the user experience remains consistent for your users.
 
-A sample `InMemoryStickyBucketService` implementation is provided for reference, but in production you will definitely want to implement your own version using a database, cookies, or similar for persistence.
+A sample `InMemoryStickyBucketService` implementation is provided for reference. Note that it only persists within a single request, so it is not suitable for production on its own.
+
+For production, the SDK ships a `Psr16StickyBucketService` that persists assignments in any PSR-16 (SimpleCache) backend you already use — Redis, Memcached, APCu, filesystem, etc. — without adding a dependency on a specific client:
+
+```php
+// $cache is any \Psr\SimpleCache\CacheInterface implementation
+$service = new Growthbook\Psr16StickyBucketService($cache);
+
+// Optional: TTL in seconds (null = the cache's default), and a key prefix
+$service = new Growthbook\Psr16StickyBucketService($cache, 15552000, 'gbStickyBuckets_');
+
+$growthbook = Growthbook\Growthbook::create()
+  ->withStickyBucketing($service);
+```
+
+Alternatively you can implement your own `StickyBucketService` using a database, cookies, or similar.
 
 Sticky Bucket documents contain three fields
 

--- a/src/Growthbook.php
+++ b/src/Growthbook.php
@@ -767,12 +767,13 @@ class Growthbook implements LoggerAwareInterface
                     }
                 }
 
+                $ruleFallback = ($this->stickyBucketService && !$rule->disableStickyBucketing) ? $rule->fallbackAttribute : null;
                 if (isset($rule->force)) {
                     if (
                         !$this->isIncludedInRollout(
                             $rule->seed ?? $key,
                             $rule->hashAttribute,
-                            $rule->fallbackAttribute,
+                            $ruleFallback,
                             $rule->range,
                             $rule->coverage,
                             $rule->hashVersion
@@ -861,7 +862,8 @@ class Growthbook implements LoggerAwareInterface
             return new ExperimentResult($exp, "id", "", -1, false, $featureId);
         }
 
-        list($hashAttribute, $hashValue) = $this->getHashValue($exp->hashAttribute, $exp->fallbackAttribute);
+        $fallback = ($this->stickyBucketService && !$exp->disableStickyBucketing) ? $exp->fallbackAttribute : null;
+        list($hashAttribute, $hashValue) = $this->getHashValue($exp->hashAttribute, $fallback);
         // 3. Forced via querystring
         if ($this->url) {
             $qsOverride = static::getQueryStringOverride($exp->key, $this->url, count($exp->variations));
@@ -1601,6 +1603,7 @@ class Growthbook implements LoggerAwareInterface
         $bucketVersion = $bucketVersion ?? 0;
         $minBucketVersion = $minBucketVersion ?? 0;
         $meta = $meta ?? [];
+        $hashAttribute = $hashAttribute ?: "id";
         $id = $this->getStickyBucketExperimentKey($key, $bucketVersion);
         $assignments = $this->getStickyBucketAssignments($hashAttribute, $fallbackAttribute);
 

--- a/src/InMemoryStickyBucketService.php
+++ b/src/InMemoryStickyBucketService.php
@@ -9,10 +9,10 @@ class InMemoryStickyBucketService extends StickyBucketService
 
     /**
      * @param string $attributeName
-     * @param mixed $attributeValue
+     * @param string $attributeValue
      * @return array<string,mixed>|null
      */
-    public function getAssignments(string $attributeName, $attributeValue): ?array
+    public function getAssignments(string $attributeName, string $attributeValue): ?array
     {
         return $this->docs[$this->getKey($attributeName, $attributeValue)] ?? null;
     }

--- a/src/InlineExperiment.php
+++ b/src/InlineExperiment.php
@@ -97,10 +97,7 @@ class InlineExperiment
         $this->minBucketVersion = $options["minBucketVersion"] ?? null;
         $this->parentConditions = $options["parentConditions"] ?? null;
         $this->customFields = $options["customFields"] ?? null;
-        $this->fallbackAttribute = null;
-        if (!is_null($this->disableStickyBucketing)) {
-            $this->fallbackAttribute = $options["fallbackAttribute"] ?? null;
-        }
+        $this->fallbackAttribute = $options["fallbackAttribute"] ?? null;
     }
 
     /**

--- a/src/Psr16StickyBucketService.php
+++ b/src/Psr16StickyBucketService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Growthbook;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Sticky bucket service backed by any PSR-16 (SimpleCache) implementation.
+ *
+ * This lets sticky bucket assignments persist across requests using whatever
+ * cache backend the application already has (Redis, Memcached, APCu, filesystem,
+ * etc.) without adding a hard dependency on any specific client.
+ */
+class Psr16StickyBucketService extends StickyBucketService
+{
+    /** @var CacheInterface */
+    private $cache;
+
+    /** @var int|null TTL in seconds; null uses the cache implementation's default */
+    private $ttl;
+
+    /** @var string Prefix applied to cache keys to avoid collisions with other cached data */
+    private $prefix;
+
+    /**
+     * @param CacheInterface $cache  Any PSR-16 cache implementation
+     * @param int|null       $ttl    TTL in seconds (null = cache default / persist)
+     * @param string         $prefix Cache key prefix
+     */
+    public function __construct(CacheInterface $cache, ?int $ttl = null, string $prefix = "gbStickyBuckets_")
+    {
+        $this->cache = $cache;
+        $this->ttl = $ttl;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @param string $attributeName
+     * @param string $attributeValue
+     * @return array<string,mixed>|null
+     */
+    public function getAssignments(string $attributeName, string $attributeValue): ?array
+    {
+        $raw = $this->cache->get($this->cacheKey($attributeName, $attributeValue));
+        if (!is_string($raw)) {
+            return null;
+        }
+        $decoded = json_decode($raw, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param array<string,mixed> $doc
+     * @return void
+     */
+    public function saveAssignments(array $doc): void
+    {
+        $key = $this->cacheKey($doc['attributeName'], $doc['attributeValue']);
+        $this->cache->set($key, (string) json_encode($doc), $this->ttl);
+    }
+
+    /**
+     * Batch-load all documents in a single cache round-trip (PSR-16 getMultiple).
+     *
+     * @param array<string, string> $attributes
+     * @return array<string, mixed>
+     */
+    public function getAllAssignments(array $attributes): array
+    {
+        // Map each (prefixed, hashed) cache key back to its logical "attr||value" doc key
+        $docKeyByCacheKey = [];
+        foreach ($attributes as $attributeName => $attributeValue) {
+            $docKeyByCacheKey[$this->cacheKey($attributeName, $attributeValue)] = $this->getKey($attributeName, $attributeValue);
+        }
+
+        if (!$docKeyByCacheKey) {
+            return [];
+        }
+
+        $docs = [];
+        foreach ($this->cache->getMultiple(array_keys($docKeyByCacheKey)) as $cacheKey => $raw) {
+            if (!is_string($raw)) {
+                continue;
+            }
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                $docs[$docKeyByCacheKey[$cacheKey]] = $decoded;
+            }
+        }
+
+        return $docs;
+    }
+
+    /**
+     * Build a PSR-16-safe cache key. The raw "attr||value" key may contain characters
+     * reserved by PSR-16 ({}()/\@:), so it is hashed to guarantee a valid key.
+     *
+     * @param string $attributeName
+     * @param string $attributeValue
+     * @return string
+     */
+    private function cacheKey(string $attributeName, string $attributeValue): string
+    {
+        return $this->prefix . md5($this->getKey($attributeName, $attributeValue));
+    }
+}

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1680,4 +1680,45 @@ final class GrowthbookTest extends TestCase
 
         $this->assertSame('default', $gb->getValue('my-feature', 'x'), 'fallback must not be used when disableStickyBucketing is true');
     }
+
+    /**
+     * Regression guard for the bug reported in growthbook-swift #125: when multiple
+     * experiments are evaluated, the sticky bucket assignment doc must ACCUMULATE all
+     * assignments rather than being reset to a single one on each evaluation.
+     */
+    public function testStickyBucketAccumulatesAcrossMultipleExperiments(): void
+    {
+        $service = new InMemoryStickyBucketService();
+        $features = [
+            'feat-a' => ['defaultValue' => 'a0', 'rules' => [[
+                'key' => 'exp-a',
+                'variations' => ['a0', 'a1'],
+                'meta' => [['key' => '0'], ['key' => '1']],
+                'coverage' => 1,
+                'weights' => [0.5, 0.5],
+            ]]],
+            'feat-b' => ['defaultValue' => 'b0', 'rules' => [[
+                'key' => 'exp-b',
+                'variations' => ['b0', 'b1'],
+                'meta' => [['key' => '0'], ['key' => '1']],
+                'coverage' => 1,
+                'weights' => [0.5, 0.5],
+            ]]],
+        ];
+
+        $gb = Growthbook::create()
+            ->withStickyBucketing($service, null)
+            ->withFeatures($features)
+            ->withAttributes(['id' => 'user-1']);
+
+        $gb->getFeature('feat-a');
+        $gb->getFeature('feat-b');
+
+        // A single doc for id||user-1 must hold BOTH experiment assignments
+        $doc = $service->getAssignments('id', 'user-1');
+        $this->assertNotNull($doc);
+        assert(is_array($doc));
+        $this->assertArrayHasKey('exp-a__0', $doc['assignments'], 'first experiment assignment must persist');
+        $this->assertArrayHasKey('exp-b__0', $doc['assignments'], 'second experiment assignment must persist');
+    }
 }

--- a/tests/GrowthbookTest.php
+++ b/tests/GrowthbookTest.php
@@ -1634,4 +1634,50 @@ final class GrowthbookTest extends TestCase
             $this->assertCount(2, $range, 'FeatureRule ranges must round-trip as [start, end] arrays');
         }
     }
+
+    // ---------------------------------------------------------------------
+    // Sticky bucketing - fallbackAttribute vs disableStickyBucketing
+    // ---------------------------------------------------------------------
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fallbackGuardFeature(bool $disableStickyBucketing): array
+    {
+        $rule = [
+            'key' => 'my-exp',
+            'hashAttribute' => 'id',          // missing from attributes -> empty primary
+            'fallbackAttribute' => 'deviceId', // present in attributes
+            'variations' => ['control', 'variation'],
+            'meta' => [['key' => '0'], ['key' => '1']],
+            'coverage' => 1,
+            'weights' => [0.5, 0.5],
+        ];
+        if ($disableStickyBucketing) {
+            $rule['disableStickyBucketing'] = true;
+        }
+        return ['my-feature' => ['defaultValue' => 'default', 'rules' => [$rule]]];
+    }
+
+    public function testFallbackUsedWhenStickyBucketingEnabled(): void
+    {
+        // Sticky enabled + empty primary 'id' -> hashing falls back to deviceId -> user is bucketed
+        $gb = Growthbook::create()
+            ->withStickyBucketing(new InMemoryStickyBucketService(), null)
+            ->withAttributes(['deviceId' => 'd123'])
+            ->withFeatures($this->fallbackGuardFeature(false));
+
+        $this->assertNotSame('default', $gb->getValue('my-feature', 'x'), 'fallback should be used when sticky bucketing is enabled');
+    }
+
+    public function testFallbackNotUsedWhenStickyBucketingDisabled(): void
+    {
+        // disableStickyBucketing=true -> fallback must NOT be used -> primary 'id' empty -> not in experiment -> default
+        $gb = Growthbook::create()
+            ->withStickyBucketing(new InMemoryStickyBucketService(), null)
+            ->withAttributes(['deviceId' => 'd123'])
+            ->withFeatures($this->fallbackGuardFeature(true));
+
+        $this->assertSame('default', $gb->getValue('my-feature', 'x'), 'fallback must not be used when disableStickyBucketing is true');
+    }
 }

--- a/tests/Psr16StickyBucketServiceTest.php
+++ b/tests/Psr16StickyBucketServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Growthbook\Growthbook;
+use Growthbook\Psr16StickyBucketService;
+use PHPUnit\Framework\TestCase;
+
+final class Psr16StickyBucketServiceTest extends TestCase
+{
+    /**
+     * Build an array-backed PSR-16 cache (signature-agnostic across psr/simple-cache 2.x/3.x).
+     */
+    private function arrayCache(): \Psr\SimpleCache\CacheInterface
+    {
+        $store = [];
+        $cache = $this->createMock(\Psr\SimpleCache\CacheInterface::class);
+        $cache->method('set')->willReturnCallback(function ($key, $value) use (&$store) {
+            $store[$key] = $value;
+            return true;
+        });
+        $cache->method('get')->willReturnCallback(function ($key, $default = null) use (&$store) {
+            return $store[$key] ?? $default;
+        });
+        $cache->method('getMultiple')->willReturnCallback(function ($keys, $default = null) use (&$store) {
+            $result = [];
+            foreach ($keys as $key) {
+                $result[$key] = $store[$key] ?? $default;
+            }
+            return $result;
+        });
+        $cache->method('has')->willReturnCallback(function ($key) use (&$store) {
+            return isset($store[$key]);
+        });
+        $cache->method('delete')->willReturnCallback(function ($key) use (&$store) {
+            unset($store[$key]);
+            return true;
+        });
+        return $cache;
+    }
+
+    /**
+     * @param array<string, string> $assignments
+     * @return array<string,mixed>
+     */
+    private function doc(string $name, string $value, array $assignments): array
+    {
+        return ['attributeName' => $name, 'attributeValue' => $value, 'assignments' => $assignments];
+    }
+
+    public function testSaveAndGetRoundTrip(): void
+    {
+        $service = new Psr16StickyBucketService($this->arrayCache());
+
+        $service->saveAssignments($this->doc('id', 'user-1', ['exp__0' => '1']));
+
+        $loaded = $service->getAssignments('id', 'user-1');
+        $this->assertNotNull($loaded);
+        assert(is_array($loaded));
+        $this->assertSame('id', $loaded['attributeName']);
+        $this->assertSame('user-1', $loaded['attributeValue']);
+        $this->assertSame(['exp__0' => '1'], $loaded['assignments']);
+    }
+
+    public function testGetReturnsNullForMissing(): void
+    {
+        $service = new Psr16StickyBucketService($this->arrayCache());
+        $this->assertNull($service->getAssignments('id', 'nobody'));
+    }
+
+    public function testGetAllAssignmentsBatch(): void
+    {
+        $service = new Psr16StickyBucketService($this->arrayCache());
+        $service->saveAssignments($this->doc('id', 'user-1', ['exp__0' => '1']));
+        $service->saveAssignments($this->doc('deviceId', 'd-9', ['exp__0' => '2']));
+
+        $docs = $service->getAllAssignments(['id' => 'user-1', 'deviceId' => 'd-9', 'missing' => 'x']);
+
+        // keyed by "attr||value"; missing attribute is omitted
+        $this->assertCount(2, $docs);
+        $this->assertSame(['exp__0' => '1'], $docs['id||user-1']['assignments']);
+        $this->assertSame(['exp__0' => '2'], $docs['deviceId||d-9']['assignments']);
+        $this->assertArrayNotHasKey('missing||x', $docs);
+    }
+
+    public function testHandlesReservedCharactersInAttributeValue(): void
+    {
+        // PSR-16 reserves {}()/\@: in keys; the service hashes the key so these are safe
+        $service = new Psr16StickyBucketService($this->arrayCache());
+        $value = 'user@example.com/path:1';
+
+        $service->saveAssignments($this->doc('email', $value, ['exp__0' => '1']));
+
+        $loaded = $service->getAssignments('email', $value);
+        $this->assertNotNull($loaded);
+        assert(is_array($loaded));
+        $this->assertSame(['exp__0' => '1'], $loaded['assignments']);
+    }
+
+    public function testIntegrationPersistsViaSharedCache(): void
+    {
+        $cache = $this->arrayCache();
+        $features = [
+            'exp-feature' => [
+                'defaultValue' => 'control',
+                'rules' => [[
+                    'key' => 'my-exp',
+                    'variations' => ['control', 'red', 'blue'],
+                    'meta' => [['key' => '0'], ['key' => '1'], ['key' => '2']],
+                    'coverage' => 1,
+                    'weights' => [0.34, 0.33, 0.33],
+                ]],
+            ],
+        ];
+
+        // First instance evaluates and persists the sticky assignment into the shared cache
+        $gb1 = Growthbook::create()
+            ->withStickyBucketing(new Psr16StickyBucketService($cache), null)
+            ->withFeatures($features)
+            ->withAttributes(['id' => 'user-1']);
+        $v1 = $gb1->getValue('exp-feature', 'none');
+
+        // The assignment must be persisted and retrievable from the shared cache
+        $persisted = (new Psr16StickyBucketService($cache))->getAssignments('id', 'user-1');
+        $this->assertNotNull($persisted, 'sticky assignment should be persisted to the PSR-16 cache');
+        assert(is_array($persisted));
+        $this->assertArrayHasKey('assignments', $persisted);
+
+        // A fresh instance sharing the same cache reads back the same variation
+        $gb2 = Growthbook::create()
+            ->withStickyBucketing(new Psr16StickyBucketService($cache), null)
+            ->withFeatures($features)
+            ->withAttributes(['id' => 'user-1']);
+        $v2 = $gb2->getValue('exp-feature', 'none');
+
+        $this->assertSame($v1, $v2);
+    }
+}


### PR DESCRIPTION
## Summary

Three sticky-bucketing improvements:

1. **fix:** don't use `fallbackAttribute` when sticky bucketing is disabled;
2. **feat:** add a production-ready PSR-16 sticky bucket service;
3. **test:** regression test for multi-experiment assignment accumulation.

## 1. fix: don't use `fallbackAttribute` when sticky bucketing is disabled;

`fallbackAttribute` is a sticky-bucketing-only concept, but it was passed into hash-value resolution unconditionally — so an experiment/rule with `disableStickyBucketing: true` could still fall back to it for hashing whenever a sticky bucket service was configured.

Fixed with the same call-site guard the canonical TS and Java SDKs use: `fallbackAttribute` is only passed when `stickyBucketService` is set **and** `disableStickyBucketing` is not `true` (the rollout and experiment paths here). `getStickyBucketVariation` also now defaults `hashAttribute` to `"id"` to match TS.

## 2. feat: add `Psr16StickyBucketService`;

The only built-in service so far was `InMemoryStickyBucketService`, which doesn't persist across requests and so isn't usable in production on its own. `Psr16StickyBucketService` persists assignments in any PSR-16 (SimpleCache) backend the app already uses — Redis, Memcached, APCu, filesystem — without depending on a specific client (PSR-16 is already a dependency):

```php
$service = new Growthbook\Psr16StickyBucketService($cache); // optional: ttl, key prefix
$gb = Growthbook\Growthbook::create()->withStickyBucketing($service);
```

- Documents are JSON-encoded; cache keys are hashed so PSR-16-reserved characters in attribute values (`@ / : { }`) are safe.
- `getAllAssignments` is overridden to use `getMultiple` (one batched round-trip instead of N lookups).

## 3. test: guard sticky bucket accumulation across experiments
Regression test for the scenario from `growthbook/growthbook-swift#125`: when multiple experiments are evaluated, the sticky bucket document must accumulate all assignments rather than being reset to a single one. The PHP SDK already behaves correctly (assignment docs are persistent instance state, merged on save); this test locks that behaviour in.